### PR TITLE
feat(build) build based on specified version instead of image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY test_plugin_entrypoint.sh /kong/bin/test_plugin_entrypoint.sh
 # LuaRocks needs unzip to unpack rocks, and dev essentials to build
 # setup the developemnt dependencies using the make target
 # and make the entrypoint executable
-RUN apk add unzip make g++ \
+RUN apk update \
+    && apk add unzip make g++ \
     && cd /kong \
     && make dependencies \
     && chmod +x /kong/bin/test_plugin_entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -27,14 +27,18 @@ Actions:
   down          remove all containers
 
 Environment variables:
+  KONG_VERSION  the specific Kong version to use when building the test image
+
   KONG_IMAGE    the base Kong Docker image to use when building the test image
 
   KONG_LICENSE_DATA
                 set this variable with the Kong Enterprise license data
 
 Example usage:
-  KONG_IMAGE=kong-ee $(basename $0) run
-  $(basename $0) down
+  pongo run
+  KONG_VERSION=0.36-1 pongo run
+  KONG_IMAGE=kong-ee pongo run
+  pongo down
 ```
 
 # pongo
@@ -44,9 +48,10 @@ Pongo provides a simple way of testing Kong Enterprise plugins
 
 Set up the following:
 
-* Have a docker image of Kong Enterprise, and set the image name in the
-  environment variable `KONG_IMAGE`.
 * Have the Kong Enterprise license key, and set it in `KONG_LICENSE_DATA`.
+* Have a docker image of Kong Enterprise, and set the image name in the
+  environment variable `KONG_IMAGE`, or alternatively log in to Bintray before
+  running Pongo.
 
 ## Installation
 
@@ -69,7 +74,14 @@ Get a shell into your plugin repository, and run `pongo`, for example:
 git clone git@github.com:Kong/kong-plugin.git
 cd kong-plugin
 
+# auto pull and build the test images (log into bintray first!)
 pongo run ./spec
+
+# Run against a specific version of Kong (log into bintray first!)
+KONG_VERSION=0.36-1 pongo run ./spec
+
+# Run against a local image of Kong
+KONG_IMAGE=kong-ee pongo run ./spec
 ```
 
 The above command (`pongo run`) will automatically build the test image and

--- a/set_variables.sh
+++ b/set_variables.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # List of supported Kong versions, last one will be used as default
-KONG_EE_VERSIONS="0.36 0.36-1 0.36-2"
-# Pre 0.36 is not supported (make target 'dependencies' is missing)
+KONG_EE_VERSIONS="0.36-1 0.36-2"
+# 0.36 is not supported because LuaRocks was borked in that version
 
 
 # loop over and keep the last one as the default

--- a/test_plugin_entrypoint.sh
+++ b/test_plugin_entrypoint.sh
@@ -45,4 +45,6 @@ if [ -z "$KONG_TEST_DNS_RESOLVER" ]; then
   export "KONG_TEST_DNS_RESOLVER=$KONG_DNS_RESOLVER"
 fi
 
+echo "Kong version: $(kong version)"
+
 exec "$@"


### PR DESCRIPTION
When supplying a version, it will automatically pull the proper
images from bintray (if logged in), or use the local ones if
already available.

If no image or version is specified, it will default the latest
Enterprise release in the list (0.36-2 currently)

This builds on top of #8 