### PR TITLE
feat(test) install dependencies before testing

### DIFF
--- a/test_plugin_entrypoint.sh
+++ b/test_plugin_entrypoint.sh
@@ -13,6 +13,18 @@ if [ -f /kong-plugin/.busted ]; then
   cp /kong-plugin/.busted /kong/
 fi
 
+# if there is a rockspec, then install it first, so we get any required
+# dependencies installed before testing
+if [ -f /kong-plugin/*.rockspec ]; then
+  old_dir="$PWD"
+  cd /kong-plugin
+  for rockspec in $(ls /kong-plugin/*.rockspec); do
+    luarocks install --only-deps $rockspec
+  done
+  cd "$old_dir"
+  unset old_dir
+fi
+
 # add the plugin code to the LUA_PATH such that the plugin will be found
 export "LUA_PATH=/kong-plugin/?.lua;/kong-plugin/?/init.lua;;"
 


### PR DESCRIPTION
If a plugin has dependencies, then the tests will fail. This PR
will, before testing, install all dependencies found in local
'*.rockspec' files using LuaRocks.