### PR TITLE
feat(tail) add a tail command to follow logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Actions:
   run           run spec files, accepts Busted options and spec files/folders
                 as arguments, see: 'pongo run -- --help'
 
+  tail          starts a tail on the specified file. Default file is
+                ./servroot/logs/error.log, an alternate file can be specified
+
   shell         get a shell directly on a kong container
 
   down          remove all dependency containers
@@ -105,8 +108,14 @@ pongo down
 When running the tests, the Kong prefix (or working directory) will be set to
 `./servroot`.
 
-So to track what is happening you can use a `tail` on `./servroot/logs/error.log`
-like this:
+To track the error log (where any `print` or `ngx.log` statements will go) you
+can use the tail command
+
+```shell
+pongo tail
+```
+
+The above would be identical to:
 
 ```shell
 tail -F ./servroot/logs/error.log

--- a/pongo.sh
+++ b/pongo.sh
@@ -51,6 +51,9 @@ Actions:
   run           run spec files, accepts Busted options and spec files/folders
                 as arguments, see: '$(basename $0) run -- --help'
 
+  tail          starts a tail on the specified file. Default file is
+                ./servroot/logs/error.log, an alternate file can be specified
+
   shell         get a shell directly on a kong container
 
   down          remove all dependency containers
@@ -309,6 +312,28 @@ function main {
 
   up)
     compose_up
+    ;;
+
+  tail)
+    local tail_file="${EXTRA_ARGS[1]}"
+    if [[ "$tail_file" == "" ]]; then
+      tail_file="./servroot/logs/error.log"
+    fi
+
+    if [[ ! -f $tail_file ]]; then
+      echo "waiting for tail file to appear: $tail_file"
+      local index=1
+      while [ $index -le 300 ]
+      do
+        if [[ -f $tail_file ]]; then
+          break
+        fi
+        let index++
+        sleep 1
+      done
+    fi
+
+    tail -F "$tail_file"
     ;;
 
   run)


### PR DESCRIPTION
implements standard 'tail -F <file>' but waits for (max) 2 minutes initially for the file to appear.

The default file is './servroot/logs/error.log'.