### PR TITLE
feat(setup) adds an optional initialization script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY test_plugin_entrypoint.sh /kong/bin/test_plugin_entrypoint.sh
 # Setup the developemnt dependencies using the make target
 # and make the entrypoint executable
 RUN apk update \
-    && apk add unzip make g++ py-pip jq \
+    && apk add unzip make g++ py-pip jq git \
     && pip install httpie \
     && cd /kong \
     && make dependencies \

--- a/README.md
+++ b/README.md
@@ -121,6 +121,38 @@ The above would be identical to:
 tail -F ./servroot/logs/error.log
 ```
 
+## Test initialization
+
+By default when the test container is started, it will look for a `.rockspec`
+file, if it find one, then it will install that rockspec file with the
+`--deps-only` flag. Meaning it will not install that rock itself, but if it
+depends on any external libraries, those rocks will be installed.
+
+For example; the Kong plugin `session` relies on the `lua-resty-session` rock.
+So by default it will install that dependency before starting the tests.
+
+An alternate way is to provide a `.pongo-setup.sh` file. If that file is present
+then that file will be executed (using `source`), instead of the default behaviour.
+
+For example, the following `.pongo-setup.sh` file will install a specific
+development branch of `lua-resty-session` instead of the one specified in
+the rockspec:
+
+```shell
+# remove any existing version if installed
+luarocks remove lua-resty-session --force
+
+git clone https://github.com/Tieske/lua-resty-session
+cd lua-resty-session
+
+# now checkout and install the development branch
+git checkout redis-ssl
+luarocks make
+
+cd ..
+rm -rf lua-resty-session
+```
+
 ## How it works
 
 The repo has 3 main components;

--- a/test_plugin_entrypoint.sh
+++ b/test_plugin_entrypoint.sh
@@ -13,10 +13,6 @@ if [ -f /kong-plugin/.busted ]; then
   cp /kong-plugin/.busted /kong/
 fi
 
-# if there is a rockspec, then install it first, so we get any required
-# dependencies installed before testing
-find /kong-plugin -maxdepth 1 -type f -name '*.rockspec' -exec luarocks install --only-deps {} \;
-
 # add the plugin code to the LUA_PATH such that the plugin will be found
 export "LUA_PATH=/kong-plugin/?.lua;/kong-plugin/?/init.lua;;"
 
@@ -49,6 +45,18 @@ if [ -z "$KONG_TEST_DNS_RESOLVER" ]; then
   export "KONG_TEST_DNS_RESOLVER=$KONG_DNS_RESOLVER"
 fi
 
-echo "Kong version: $(kong version)"
 
+
+# perform any custom setup if specified
+if [ -f /kong-plugin/.pongo-setup.sh ]; then
+  source /kong-plugin/.pongo-setup.sh
+else
+  # if there is a rockspec, then install it first, so we get any required
+  # dependencies installed before testing
+  find /kong-plugin -maxdepth 1 -type f -name '*.rockspec' -exec luarocks install --only-deps {} \;
+fi
+
+
+
+echo "Kong version: $(kong version)"
 exec "$@"


### PR DESCRIPTION
Default behaviour is to install the local rockspec without dependencies. When a `./pongo-setup.sh` file is available, then that will be executed instead.