### PR TITLE
fix(postgres) remove healthcheck errors from pg logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       test:
       - CMD
       - pg_isready
-      - -U
-      - kong
+      - --dbname=kong_tests
+      - --username=kong
       timeout: 10s
     networks:
       - kong-plugin-test-network


### PR DESCRIPTION
database name was not specified hence getting repetitive fatal errors
from the healthcheck.
Db was online, so health was positive, but an error was logged

This removes the noise by providing the proper db name

```
postgres_1   | FATAL:  database "kong" does not exist
postgres_1   | FATAL:  database "kong" does not exist
postgres_1   | FATAL:  database "kong" does not exist
postgres_1   | FATAL:  database "kong" does not exist
postgres_1   | FATAL:  database "kong" does not exist
postgres_1   | FATAL:  database "kong" does not exist
```