### PR TITLE
Removing -it flag from docker run command in pongo.sh

### DIFF
--- a/pongo.sh
+++ b/pongo.sh
@@ -211,7 +211,7 @@ function get_version {
     get_image
   fi
 
-  VERSION=$(docker run -it --rm -e KONG_LICENSE_DATA "$KONG_IMAGE" "${cmd[@]}")
+  VERSION=$(docker run --rm -e KONG_LICENSE_DATA "$KONG_IMAGE" "${cmd[@]}")
   KONG_TEST_IMAGE=$IMAGE_BASE_NAME:$VERSION
 }
 


### PR DESCRIPTION
Is the -it flag needed in the docker run command? 