### PR TITLE
feat(version) allow for latest patch release

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Actions:
 
 Environment variables:
   KONG_VERSION  the specific Kong version to use when building the test image
+                (note that the patch-version can be 'x' to use latest)
 
   KONG_IMAGE    the base Kong Docker image to use when building the test image
 
@@ -56,7 +57,7 @@ Environment variables:
 
 Example usage:
   pongo run
-  KONG_VERSION=0.36-1 pongo run -v -o gtest ./spec/02-access_spec.lua
+  KONG_VERSION=1.3.x pongo run -v -o gtest ./spec/02-access_spec.lua
   POSTGRES=9.4 KONG_IMAGE=kong-ee pongo run
   pongo down
 ```
@@ -106,6 +107,9 @@ pongo run ./spec
 # Run against a specific version of Kong (log into bintray first!) and pass
 # a number of Busted options
 KONG_VERSION=0.36-1 pongo run -v -o gtest ./spec
+
+# Run against the latest patch version of a Kong release using '.x'
+KONG_VERSION=1.2.x pongo run -v -o gtest ./spec
 
 # Run against a local image of Kong
 KONG_IMAGE=kong-ee pongo run ./spec

--- a/assets/set_variables.sh
+++ b/assets/set_variables.sh
@@ -53,3 +53,22 @@ function version_exists {
   done;
   return 1
 }
+
+# resolve the KONG_VERSION in place
+function resolve_version {
+  if [[ "${KONG_VERSION: -1}" == "x" ]]; then
+    local new_version=$KONG_VERSION
+    for entry in ${KONG_VERSIONS[*]}; do
+      if [[ "${KONG_VERSION:0:${#KONG_VERSION}-1}" == "${entry:0:${#entry}-1}" ]]; then
+        # keep replacing, last one wins
+        new_version=$entry
+      fi
+    done;
+    if [[ "$new_version" == "$KONG_VERSION" ]]; then
+      echo "Could not resolve Kong version: $KONG_VERSION"
+    else
+      echo "Resolved Kong version $KONG_VERSION to $new_version"
+      KONG_VERSION=$new_version
+    fi
+  fi
+}

--- a/pongo.sh
+++ b/pongo.sh
@@ -18,6 +18,8 @@ function globals {
   EXTRA_ARGS=()
 
   source ${LOCAL_PATH}/assets/set_variables.sh
+  # resolve a '.x' to a real version; eg. "1.3.0.x" in $KONG_VERSION
+  resolve_version
 
   unset CUSTOM_PLUGINS
   unset PLUGINS
@@ -72,6 +74,7 @@ Actions:
 
 Environment variables:
   KONG_VERSION  the specific Kong version to use when building the test image
+                (note that the patch-version can be 'x' to use latest)
 
   KONG_IMAGE    the base Kong Docker image to use when building the test image
 
@@ -84,7 +87,7 @@ Environment variables:
 
 Example usage:
   $(basename $0) run
-  KONG_VERSION=0.36-1 $(basename $0) run -v -o gtest ./spec/02-access_spec.lua
+  KONG_VERSION=1.3.x $(basename $0) run -v -o gtest ./spec/02-access_spec.lua
   POSTGRES=9.4 KONG_IMAGE=kong-ee $(basename $0) run
   $(basename $0) down
 


### PR DESCRIPTION
Instead of specifying a complete version, one can now specify a `.x` and get the latest patch release for that version. In preparation of using Pongo for CI.

```shell
KONG_VERSION=1.3.0.x pongo run
```
Will resolve the version to `1.3.0.1` (current latest within `1.3.0.x` range) and then run against that version