### PR TITLE
feat(proxy) add squid as a forward-proxy test dependency

### DIFF
--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -49,6 +49,15 @@ services:
     networks:
       - kong-plugin-test-network
 
+  squid:
+    image: sameersbn/squid:${SQUID:-3.5.27-2}
+    volumes:
+      - ./squid.conf:/etc/squid/squid.conf
+      - ./squid.passwords:/etc/squid/passwords
+    restart: on-failure
+    networks:
+      - kong-plugin-test-network
+
   kong:
     image: ${KONG_TEST_IMAGE:-ignore_if_not_provided}
     environment:

--- a/assets/squid.conf
+++ b/assets/squid.conf
@@ -1,0 +1,27 @@
+# squid conf
+
+# configure auth
+auth_param basic program /usr/lib/squid3/basic_ncsa_auth /etc/squid/passwords
+auth_param basic realm Squid proxy-caching web server
+
+# exposed proxy ports
+http_port 3128
+https_port 3128
+
+acl whitelist dstdomain .mockbin.org
+acl http proto http
+acl port_80 port 80
+acl port_443 port 443
+acl CONNECT method CONNECT
+acl authenticated_users proxy_auth REQUIRED
+
+# rules allowing non-authenticated users
+http_access allow http port_80 whitelist
+http_access allow CONNECT port_443 whitelist
+
+# rules allowing authenticated users
+http_access allow http port_80 authenticated_users
+http_access allow CONNECT port_443 authenticated_users
+
+# catch-all rule
+http_access deny all

--- a/assets/squid.passwords
+++ b/assets/squid.passwords
@@ -1,0 +1,2 @@
+# below line is user: "kong", password "king"
+kong:$apr1$KOerCLY.$cFsyOxq8OH8EygvA2k1/V.

--- a/pongo.sh
+++ b/pongo.sh
@@ -13,7 +13,7 @@ function globals {
   KONG_TEST_PLUGIN_PATH=$(realpath .)
 
   unset ACTION
-  KONG_DEPS_AVAILABLE=( "postgres" "cassandra" "redis" )
+  KONG_DEPS_AVAILABLE=( "postgres" "cassandra" "redis" "squid")
   KONG_DEPS_START=( "postgres" "cassandra" )
   EXTRA_ARGS=()
 
@@ -63,6 +63,7 @@ Options:
   --no-cassandra     do not start cassandra db
   --no-postgres      do not start postgres db
   --redis            do start redis db (available at 'redis:6379')
+  --squid            do start squid forward-proxy (see readme for info)
 
 Actions:
   up            start required dependency containers for testing
@@ -102,6 +103,7 @@ Environment variables:
   POSTGRES      the version of the Postgres dependency to use (default 9.5)
   CASSANDRA     the version of the Cassandra dependency to use (default 3.9)
   REDIS         the version of the Redis dependency to use (default 5.0.4)
+  SQUID         the version of the Squid dependency to use (default 3.5.27-2)
 
 Example usage:
   $(basename $0) run


### PR DESCRIPTION
Will only be started if `--squid` is passed to the environment, see readme for details.

Added to be able to test the AWS-Lambda plugin with a forward proxy