### PR TITLE
fix(redis) use portable Redis host configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage: pongo action [options...] [--] [action options...]
 Options (can also be added to '.pongorc'):
   --no-cassandra     do not start cassandra db
   --no-postgres      do not start postgres db
-  --redis            do start redis db (available at 'redis:6379')
+  --redis            do start redis db (see readme for info)
   --squid            do start squid forward-proxy (see readme for info)
 
 Project actions:
@@ -146,8 +146,15 @@ The available dependencies are:
 
 * **Redis** key-value store
   - Enable it with `--redis`
-  - From within the environment the Redis instance is available at `redis:6379`
   - The Redis version is controlled by the `REDIS` environment variable
+  - From within the environment the Redis instance is available at `redis:6379`,
+    but from the test specs it should be accessed by using the `helpers.redis_host`
+    field, and port `6379`, to keep it portable to other test environments. Example:
+    ```shell
+    local helpers = require "spec.helpers"
+    local redis_host = helpers.redis_host
+    local redis_port = 6379
+    ```
 
 * **Squid** (forward-proxy)
   - Enable it with `--squid`

--- a/assets/test_plugin_entrypoint.sh
+++ b/assets/test_plugin_entrypoint.sh
@@ -27,6 +27,9 @@ export KONG_PREFIX=/kong-plugin/servroot
 # set debug logs; specifically for the 'shell' command, tests already have it
 export KONG_LOG_LEVEL=debug
 
+# export Pongo's redis instance to the Kong test-helpers
+export KONG_SPEC_REDIS_HOST=redis
+
 # export the KONG_ variables also in the KONG_TEST_ range
 if [ -z "$KONG_TEST_LICENSE_DATA" ]; then
   export "KONG_TEST_LICENSE_DATA=$KONG_LICENSE_DATA"

--- a/pongo.sh
+++ b/pongo.sh
@@ -63,7 +63,7 @@ Usage: $(basename $0) action [options...] [--] [action options...]
 Options (can also be added to '.pongorc'):
   --no-cassandra     do not start cassandra db
   --no-postgres      do not start postgres db
-  --redis            do start redis db (available at 'redis:6379')
+  --redis            do start redis db (see readme for info)
   --squid            do start squid forward-proxy (see readme for info)
 
 Project actions:


### PR DESCRIPTION
By using spec helpers, the plugins can also be tested on other
environments, and won't need to rely on Pongo.