### PR TITLE
feat(ci) add option to run tests against nightly builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 kong-ee/*
 kong/*
+kong-versions/nightly-ee/*
+kong-versions/nightly/*
+servroot

--- a/assets/add_version.sh
+++ b/assets/add_version.sh
@@ -85,6 +85,7 @@ fi
 
 # add the artifacts and the second commit
 source ${LOCAL_PATH}/assets/update_versions.sh
+update_artifacts
 
 if [[ ! "$?" == "99" ]]; then
   echo "Nothing was updated? nothing to commit. Please check the version"

--- a/assets/set_variables.sh
+++ b/assets/set_variables.sh
@@ -2,6 +2,9 @@
 
 # this requires LOCAL_PATH to be set to the Pongo directory
 
+# special case accepted version identifiers
+NIGHTLY_CE=nightly
+NIGHTLY_EE=nightly-ee
 
 # read config from Pongo RC file
 if [[ -f ./.pongorc ]]; then
@@ -43,7 +46,17 @@ KONG_DEFAULT_VERSION="${KONG_CE_VERSIONS[ ${#KONG_CE_VERSIONS[@]}-1 ]}"
 
 function is_enterprise {
   local check_version=$1 
-  for VERSION in ${KONG_EE_VERSIONS[*]}; do
+  for VERSION in ${KONG_EE_VERSIONS[*]} $NIGHTLY_EE; do
+    if [[ "$VERSION" == "$check_version" ]]; then
+      return 0
+    fi
+  done;
+  return 1
+}
+
+function is_nightly {
+  local check_version=$1
+  for VERSION in $NIGHTLY_CE $NIGHTLY_EE; do
     if [[ "$VERSION" == "$check_version" ]]; then
       return 0
     fi
@@ -53,7 +66,7 @@ function is_enterprise {
 
 function version_exists {
   local version=$1
-  for entry in ${KONG_VERSIONS[*]}; do
+  for entry in ${KONG_VERSIONS[*]} $NIGHTLY_CE $NIGHTLY_EE ; do
     if [[ "$version" == "$entry" ]]; then
       return 0
     fi


### PR DESCRIPTION
This implements the special values for `KONG_VERSION` to run against nightly builds; "nightly" and "nightly-ee".

The EE version is implemented, but the location (where the image is hosted) might still change. The CE version is not yet implemented.

**NOTE**: the nightly EE version is not publicly available, and hence only for Kong internal use.

For now using EE requires setting some environment variables;
 - `NIGHTLY_EE_USER`: the user id used to login to the Docker hub/repo where the nightly images are stored.
 - `NIGHTLY_EE_APIKEY`: the apikey to be granted access to the repo (when using CI this value should obviously be added to the configuration as an encrypted secret)

Example would be:

    NIGHTLY_EE_USER="my-user-id" \
    NIGHTLY_EE_APIKEY="my-sooper-secret-key" \
    KONG_VERSION="nightly-ee" \
    pongo run

