### PR TITLE
adds support for custom plugins' directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Environment variables:
 
   KONG_LICENSE_DATA
                 set this variable with the Kong Enterprise license data
+  KONG_PLUGINS_DIR
+                the path to plugins' directories (default ./kong/plugins),
+                pongo will set all custom plugins which match $KONG_PLUGINS_DIR/*/handler.lua
+                or $KONG_PLUGINS_DIR/handler.lua
 
   POSTGRES      the version of the Postgres dependency to use (default 9.5)
   CASSANDRA     the version of the Cassandra dependency to use (default 3.9)


### PR DESCRIPTION
This PR does the following:
- [X] Adds support for custom `KONG_PLUGINS_DIR` environment variable. Earlier pongo would always look for `handler.lua` in fixed `./kong/plugins/*` path
- [X] Makes pongo look for `handler.lua` in  base `$KONG_PLUGINS_DIR`
- [X] The default value of `KONG_PLUGINS_DIR` is still `./kong/plugins`, so that it does not break existing things.
- [X] Updates readme with the usage of this variable.

This PR makes adding plugins flexible, as all plugins may not follow the same directory structure convention.