### PR TITLE
Adding an env var for the license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Set up the following when testing against Kong Enterprise:
   environment variables `BINTRAY_USERNAME` and `BINTRAY_APIKEY`, or manually
   log in to the Kong docker repo.
 * Have the Kong Enterprise license key, and set it in `KONG_LICENSE_DATA`,
-  alternatively set variable `BINTRAY_REPO` to your repository name (in addition
+  alternatively set variable `BINTRAY_REPO` to your repository name and 
+  'BINTRAY_LICENSE_FILE' to to the file name of your licenses json (in addition
   to `BINTRAY_USERNAME` and `BINTRAY_APIKEY`) to allow Pongo to download the
   license file automatically.
 * If you do not have Bintray credentials, make sure to have a docker image of

--- a/pongo.sh
+++ b/pongo.sh
@@ -426,7 +426,10 @@ function get_license {
       if [[ "$BINTRAY_REPO" == "" ]]; then
         warn "BINTRAY_REPO is not set, might not be able to download the license!"
       fi
-      export KONG_LICENSE_DATA=$(curl -s -L -u"$BINTRAY_USERNAME:$BINTRAY_APIKEY" "https://kong.bintray.com/$BINTRAY_REPO/license.json")
+      if [[ "$BINTRAY_LICENSE_FILE" == "" ]]; then
+        warn "BINTRAY_LICENSE_FILE is not set, might not be able to download the license!"
+      fi
+      export KONG_LICENSE_DATA=$(curl -s -L -u"$BINTRAY_USERNAME:$BINTRAY_APIKEY" "https://kong.bintray.com/$BINTRAY_REPO/$BINTRAY_LICENSE_FILE")
       if [[ ! $KONG_LICENSE_DATA == *"signature"* || ! $KONG_LICENSE_DATA == *"payload"* ]]; then
         # the check above is a bit lame, but the best we can do without requiring
         # yet more additional dependenies like jq or similar.


### PR DESCRIPTION
Adding an environment variable for BINTRAY_LICENSE_FILE since license.json will be the initial version of the license, any new license in the repository will have a different naming convention. 