### PR TITLE
Add possibility to override KONG_SPEC_TEST_CONF_PATH in pongo run

### DIFF
--- a/pongo.sh
+++ b/pongo.sh
@@ -938,6 +938,7 @@ function main {
     compose run --rm \
       -e KONG_LICENSE_DATA \
       -e KONG_TEST_DONT_CLEAN \
+      -e KONG_SPEC_TEST_CONF_PATH \
       kong \
       "/bin/sh" "-c" "bin/busted --helper=bin/busted_helper.lua ${busted_params[*]} ${busted_files[*]}"
     ;;


### PR DESCRIPTION
I'd like to write tests for my kong plugin using pongo. 
The only strategy I'm interested in is `database = off`
Default `spec/kong_tests.conf` 
https://github.com/Kong/kong/blob/60118c78e1fba6f79957134fe434382f2e3b2b3d/spec/kong_tests.conf#L13
has `database = postgres`

Without the change in this PR and `pongorc`:
```
--no-postgres
--no-cassandra
```
I have following error running tests for my plugin
```
pongo run
[pongo-INFO] auto-starting the test environment, use the 'pongo down' action to stop it
Creating kong-pongo_kong_run ... done
Kong version: 2.1.4
[==========] Running tests from scanned files.
[----------] Global test environment setup.
[----------] Running tests from /kong-plugin/spec/my-plugin/02-access_spec.lua
./spec/helpers.lua:175: [PostgreSQL error] failed to retrieve PostgreSQL server_version_num: host or service not provided, or not known

stack traceback:
	./spec/helpers.lua:175: in main chunk
```