### PR TITLE
feat(expose) add an option to expose the service ports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ dist: bionic
 jobs:
   include:
   - name: pongo shell
-    env: TEST_SCRIPT=assets/ci/pongo_shell.test.sh
-  - name: pongo build
-    env: TEST_SCRIPT=assets/ci/pongo_build.test.sh
+    env: TEST_SCRIPT="assets/ci/pongo_shell.test.sh"
+  - name: pongo build, pongo expose
+    env: TEST_SCRIPT="assets/ci/pongo_build.test.sh assets/ci/pongo_expose.test.sh"
   - name: pongo run (CE releases)
-    env: TEST_SCRIPT=assets/ci/pongo_run_ce.test.sh
+    env: TEST_SCRIPT="assets/ci/pongo_run_ce.test.sh"
   - name: pongo run (EE releases)
-    env: TEST_SCRIPT=assets/ci/pongo_run_ee.test.sh
+    env: TEST_SCRIPT="assets/ci/pongo_run_ee.test.sh"
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Environment actions:
 
   down          remove all dependency containers
 
+  expose        expose the internal ports for access from the host
+
   restart       shortcut, a combination of; down + up
 
   status        show status of the Pongo network, images, and containers
@@ -92,6 +94,8 @@ Pongo provides a simple way of testing Kong plugins
     - [Dependency defaults](#dependency-defaults)
     - [Custom local dependencies](#custom-local-dependencies)
  - [Debugging](#debugging)
+     - [Accessing the logs](#accessing-the-logs)
+     - [Direct access to service ports](#direct-access-to-service-ports)
  - [Test initialization](#test-initialization)
  - [Setting up CI](#setting-up-ci)
      - [CI against nightly builds](#ci-against-nightly-builds)
@@ -371,6 +375,8 @@ Some helpfull examples:
 
 ## Debugging
 
+### Accessing logs
+
 When running the tests, the Kong prefix (or working directory) will be set to
 `./servroot`.
 
@@ -409,6 +415,40 @@ the working directory in between tests. And the final `cat` command will output
 the log to the Travis console.
 
 [Back to ToC](#table-of-contents)
+
+### Direct access to service ports
+
+To directly access Kong from the host, or the datastores, the `pongo expose`
+command can be used to expose the internal ports to the host.
+
+This allows for example to connect to the Postgres on port `5432` to validate
+the contents of the database. Or when running `pongo shell` to manually
+start Kong, you can access all the regular Kong ports from the host, including
+the GUI's.
+
+This has been implemented as a separate container that opens all those ports and
+relays them on the docker network to the actual service containers (the reason
+for this is that regular Pongo runs do not interfere with ports already in use
+on the host, only if `expose` is used there is a risk of failure because ports
+are already in use on the host)
+
+Since it is technically a "dependency" it can be specified as a dependency as
+well.
+
+so
+```shell
+pongo up
+pongo expose
+```
+is equivalent to
+```shell
+pongo up --expose
+```
+
+See `pongo expose --help` for the ports.
+
+[Back to ToC](#table-of-contents)
+
 
 ## Test initialization
 

--- a/assets/ci/pongo_expose.test.sh
+++ b/assets/ci/pongo_expose.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+function run_test {
+  pushd assets/ci
+  tinitialize "Pongo test suite" "${BASH_SOURCE[0]}"
+
+  tchapter "expose ports to host"
+
+  # start Pongo environment
+  pongo up --no-cassandra --postgres --expose
+  pongo build
+  sleep 5
+
+  # create a script to start kong (sleep long becasue we do not want the
+  # container to exit, pongo down will kill it later)
+  cat <<EOF > test_script
+kong migrations bootstrap --force
+kong start && sleep 86400
+EOF
+  chmod +x test_script
+
+  # run in background
+  pongo shell @test_script &
+  sleep 20
+
+
+  ttest "exposes Kong proxy port"
+
+  curl http://localhost:8000/
+  if [ $? -eq 0 ]; then
+    echo
+    tsuccess
+  else
+    echo
+    tmessage "couldn't connect to proxy port"
+    tfailure
+  fi
+
+
+  ttest "exposes Kong proxy ssl port"
+
+  curl -k https://localhost:8443/
+  if [ $? -eq 0 ]; then
+    echo
+    tsuccess
+  else
+    echo
+    tmessage "couldn't connect to proxy port"
+    tfailure
+  fi
+
+
+  ttest "exposes Kong admin port"
+
+  curl http://localhost:8001/
+  if [ $? -eq 0 ]; then
+    echo
+    tsuccess
+  else
+    echo
+    tmessage "couldn't connect to admin port"
+    tfailure
+  fi
+
+
+  ttest "exposes Kong admin ssl port"
+
+  curl -k https://localhost:8444/
+  if [ $? -eq 0 ]; then
+    echo
+    tsuccess
+  else
+    echo
+    tmessage "couldn't connect to admin port"
+    tfailure
+  fi
+
+
+  # cleanup
+  pongo down
+  rm test_script
+
+  tfinish
+  popd
+}
+
+
+# No need to modify anything below this comment
+
+# shellcheck disable=SC1090  # do not follow source
+[[ "$T_PROJECT_NAME" == "" ]] && set -e && if [[ -f "${1:-$(dirname "$(realpath "$0")")/test.sh}" ]]; then source "${1:-$(dirname "$(realpath "$0")")/test.sh}"; else source "${1:-$(dirname "$(realpath "$0")")/run.sh}"; fi && set +e
+run_test

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -5,6 +5,43 @@ networks:
     name: ${SERVICE_NETWORK_NAME}
 
 services:
+  expose:
+    image: pongo-expose
+    build: ./expose
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+      - "8002:8002"
+      - "8003:8003"
+      - "8004:8004"
+      - "8443:8443"
+      - "8444:8444"
+      - "8445:8445"
+      # Postgres
+      - "5432:5432"
+      # Cassandra
+      - "7000:7000"
+      - "7001:7001"
+      - "7199:7199"
+      - "9042:9042"
+      - "9160:9160"
+      # Redis
+      - "6379:6379"
+    environment:
+      EXPOSE: "kong:8000 kong:8001 kong:8002 kong:8003 kong:8004 kong:8443 kong:8444 kong:8445 postgres:5432 cassandra:7000 cassandra:7001 cassandra:7199 cassandra:9042 cassandra:9160 redis:6379"
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test:
+      - CMD
+      - test
+      - -e
+      - /ready
+      timeout: 10s
+    stop_signal: SIGKILL
+    networks:
+      - ${NETWORK_NAME}
+
   postgres:
     image: postgres:${POSTGRES:-9.5}
     environment:

--- a/assets/expose/Dockerfile
+++ b/assets/expose/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.11
+
+# add helper files to workaround some issues
+COPY entrypoint.sh /entrypoint.sh
+
+RUN apk --no-cache --virtual add socat
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/assets/expose/entrypoint.sh
+++ b/assets/expose/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# loop over EXPOSE
+for MAPPING in $EXPOSE ; do
+  PORT=$(echo "$MAPPING" | grep -o "[0-9]*$")
+  echo "$PORT mapped to $MAPPING"
+
+  # following command must go in background!
+  socat "TCP-LISTEN:$PORT,fork" "TCP:$MAPPING" &
+done
+
+echo "done" > /ready
+
+jobs
+wait

--- a/assets/help/expose.txt
+++ b/assets/help/expose.txt
@@ -1,0 +1,20 @@
+Usage: pongo expose
+
+Starts the expose container that will expose the internal ports. This will allow
+access to the containers from the host system. For example to connect to the
+database to validate contents.
+
+Alternatively you can specify the '--expose' dependency like any other
+dependency.
+
+
+Ports:
+  - Kong     : 8000, 8001, 8002, 8003, 8004, 8443, 8444, 8445
+  - Postgres : 5432
+  - Cassandra: 7000, 7001, 7199, 9042, 9160
+  - Redis    : 6379
+
+
+Example usage:
+  pongo expose
+  pongo up --expose

--- a/assets/help/pongo.txt
+++ b/assets/help/pongo.txt
@@ -31,6 +31,8 @@ Environment actions:
 
   down          remove all dependency containers
 
+  expose        expose the internal ports for access from the host
+
   restart       shortcut, a combination of; down + up
 
   status        show status of the Pongo network, images, and containers

--- a/assets/help/up.txt
+++ b/assets/help/up.txt
@@ -23,6 +23,7 @@ Default available dependencies:
   --grpcbin          do start grpcbin (see readme for info)
   --redis            do start redis db (see readme for info)
   --squid            do start squid forward-proxy (see readme for info)
+  --expose           exposes ports (see 'pongo expose --help')
 
 
 Environment variables:

--- a/assets/test_plugin_entrypoint.sh
+++ b/assets/test_plugin_entrypoint.sh
@@ -13,6 +13,22 @@ if [ -f /kong-plugin/.busted ]; then
   cp /kong-plugin/.busted /kong/
 fi
 
+
+if [ -z "$KONG_ADMIN_LISTEN" ]; then
+  # admin_api is by default not exposed, other than 127.0.0.1, since different
+  # Kong versions have different settings, find the default and replace it.
+  FILE_WITH_KONG_DEFAULTS=$(luarocks show kong | grep -oEi '/.*/kong_defaults.lua')
+  DEFAULT_ADMIN_LISTEN_SETTING=$(grep admin_listen < "$FILE_WITH_KONG_DEFAULTS" | sed 's/admin_listen *= *//')
+
+  # export to override defaults in file, with 0.0.0.0 instead of 127.0.0.1
+  export KONG_ADMIN_LISTEN
+  KONG_ADMIN_LISTEN=$(echo "$DEFAULT_ADMIN_LISTEN_SETTING" | sed 's/127\.0\.0\.1/0.0.0.0/g')
+
+  unset FILE_WITH_KONG_DEFAULTS
+  unset DEFAULT_ADMIN_LISTEN_SETTING
+fi
+
+
 # add the plugin code to the LUA_PATH such that the plugin will be found
 export "LUA_PATH=/kong-plugin/?.lua;/kong-plugin/?/init.lua;;"
 


### PR DESCRIPTION
This allows access from the host to the services running in the
Pongo docker network. See `pongo expose --help` for details.

The reason for this indirect exposure (as opposed to just exposing the ports on the containers themselves) is because it does not interfere with ports already in use. So regular Pongo usage does not interfere with ports on the host, only if `expose` is used it maps them, and hence fails if already in use.