### PR TITLE
chore(ci) enable nightlies

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -31,6 +31,7 @@ USER root
 # that should be independent of Kong versions.
 RUN apk update \
     && apk add zip unzip make g++ py-pip jq git bsd-compat-headers m4 openssl-dev curl \
+    && curl -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.3.0/grpcurl_1.3.0_linux_x86_64.tar.gz | tar xz -C /kong/bin \
     && pip install 'httpie<2.0.0'\
     && cd /kong \
     && make dependencies \

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -31,7 +31,7 @@ USER root
 # that should be independent of Kong versions.
 RUN apk update \
     && apk add zip unzip make g++ py-pip jq git bsd-compat-headers m4 openssl-dev curl \
-    && curl -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.3.0/grpcurl_1.3.0_linux_x86_64.tar.gz | tar xz -C /kong/bin \
+    && curl -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin \
     && pip install 'httpie<2.0.0'\
     && cd /kong \
     && make dependencies \

--- a/assets/ci/pongo_build.test.sh
+++ b/assets/ci/pongo_build.test.sh
@@ -12,7 +12,7 @@ function run_test {
   TEST_VERSION=2.0.5
 
 
-  ttest "builds the specified image: TEST_VERSION"
+  ttest "builds the specified image: $TEST_VERSION"
   KONG_VERSION=$TEST_VERSION pongo build
   KONG_VERSION=$TEST_VERSION pongo shell kong version | grep $TEST_VERSION
   if [ $? -eq 1 ]; then

--- a/assets/ci/pongo_run.helper.sh
+++ b/assets/ci/pongo_run.helper.sh
@@ -62,9 +62,6 @@ function versions_to_test {
     if [[ "$VERSION" =~ ^[0-9] ]]; then
       # numeric version, so not a nightly one; replace last digit with 'x' wildcard
       VERSION="${VERSION:0:${#VERSION}-1}x"
-    else
-      # skip nightlies...
-      VERSION=""
     fi
 
     # step 3) store version if not already in our CLEAN_VERSIONS array


### PR DESCRIPTION
Since the Kong master image now also contains the commit id, nightlies are now supported.

This PR enables them in CI.