### PR TITLE
fix(pack) also pack dev/scm rockspecs

### DIFF
--- a/assets/pongo_pack
+++ b/assets/pongo_pack
@@ -6,6 +6,6 @@
 local dir = require("pl.dir")
 local rockspecs = dir.getfiles("/kong-plugin/", "*.rockspec")
 for _, filename in ipairs(rockspecs) do
-  local rockname = filename:match("([^/]+)%-[%d%.]+%-%d%.rockspec")
+  local rockname = filename:match("([^/]+)%-[%d%.%a]+%-%d%.rockspec")
   os.execute(("cd /kong-plugin && luarocks make %s && luarocks pack %s"):format(filename, rockname))
 end


### PR DESCRIPTION
The pattern used to match the filenames only matched version
numbers. Updated to also match `xxx-dev-1.rockspec` (any letters)