### PR TITLE
fix(certs) disbale cert verification for grpccurl

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -31,9 +31,9 @@ USER root
 # that should be independent of Kong versions.
 RUN apk update \
     && apk add zip unzip make g++ py-pip jq git bsd-compat-headers m4 openssl-dev curl \
-    && curl -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin \
-    && pip install 'httpie<2.0.0'\
-    && cd /kong \
+    && curl -k -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin \
+    && pip install 'httpie<2.0.0' \
+    ; cd /kong \
     && make dependencies \
     && luarocks install busted-htest \
     && chmod +x /kong/bin/test_plugin_entrypoint.sh


### PR DESCRIPTION
Behind corporate firewalls the curl command could occasionally
not verify certs, hence the `-k` option was added. And the ;
instead of && after the `pip` command allows it to fail without
stopping the build