### PR TITLE
fix(ci) test older kong-plugin code

### DIFF
--- a/assets/ci/pongo_run.helper.sh
+++ b/assets/ci/pongo_run.helper.sh
@@ -19,9 +19,17 @@ function checkout_commit {
       COMMIT="6789fcf283e8c1e12ba7a06226fed698e25963a7"
       ;;
 
+    1.2.x|1.3.x|1.4.x|1.5.x|2.0.x|2.1.x|2.2.x)
+      COMMIT="7b9929c19df0efc0643f8f8262ba8f7b0d0439d1"
+      ;;
+
     # EE versions
     0.33-x|0.34-x|0.35-x)
       COMMIT="6789fcf283e8c1e12ba7a06226fed698e25963a7"
+      ;;
+
+    0.36-x|1.3.0.x|1.5.0.x|1.5.0.1x|2.1.3.x|2.1.4.x|2.2.0.x|2.2.1.x)
+      COMMIT="7b9929c19df0efc0643f8f8262ba8f7b0d0439d1"
       ;;
 
 


### PR DESCRIPTION
The kong-plugin was updated and now uses test helpers only
available in Kong 2.3+. So older versions of Kong should now
be tested against an older commit ID of the 'kong-plugin' repo.