### PR TITLE
Support Ubuntu images

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -29,10 +29,10 @@ USER root
 #   make dependencies
 # But that means hardcoding and that doesn't play well with the nature of Pongo
 # that should be independent of Kong versions.
-RUN apk update \
-    && apk add zip unzip make g++ py-pip jq git bsd-compat-headers m4 openssl-dev curl \
+
+RUN apt update \
+    && apt install -y zip make g++ jq m4 curl httpie \
     && curl -k -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin \
-    && pip install 'httpie<2.0.0' \
     ; cd /kong \
     && make dependencies \
     && luarocks install busted-htest \

--- a/pongo.sh
+++ b/pongo.sh
@@ -32,15 +32,15 @@ function globals {
 
   # regular Kong Enterprise images repo (tag is build as $PREFIX$VERSION$POSTFIX).
   KONG_EE_TAG_PREFIX="kong/kong-gateway:"
-  KONG_EE_TAG_POSTFIX="-alpine"
+  KONG_EE_TAG_POSTFIX="-ubuntu"
 
   # all Kong Enterprise images repo (tag is build as $PREFIX$VERSION$POSTFIX).
   KONG_EE_PRIVATE_TAG_PREFIX="kong/kong-gateway-private:"
-  KONG_EE_PRIVATE_TAG_POSTFIX="-alpine"
+  KONG_EE_PRIVATE_TAG_POSTFIX="-ubuntu"
 
   # regular Kong CE images repo (tag is build as $PREFIX$VERSION$POSTFIX)
   KONG_OSS_TAG_PREFIX="kong:"
-  KONG_OSS_TAG_POSTFIX="-alpine"
+  KONG_OSS_TAG_POSTFIX="-ubuntu"
 
   # unoffical Kong CE images repo, the fallback
   KONG_OSS_UNOFFICIAL_TAG_PREFIX="kong/kong:"


### PR DESCRIPTION
recently we ran into a plugin where we needed to interact with a precompiled C library. This failed because the Pongo uses the Alpine images. Alpine doesn't use the standard C lib, but uses Musl instead, which was incompatible.

The change in this PR changes the base to `ubunutu` which allowed us to work with the said library.

This must however be made configurable. The Kong Nightly images are Alpine only, so switching everything over is not an option.
