### PR TITLE
feat(*) pass Pongo command when starting container

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,9 @@ To modify the default behaviour there are 2 scripts that can be hooked up:
   container. It will not be executed but sourced, and will run on `/bin/sh` as
   interpreter.
 
+Both scripts will have an environment variable `PONGO_COMMAND` that will have
+the current command being executed, for example `shell` or `run`.
+
 For example, the following file (saved as `.pongo/pongo-setup.sh`) will install
 a specific development branch of `lua-resty-session` instead of the one
 specified in the rockspec:

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -122,6 +122,7 @@ services:
     environment:
       - KONG_CASSANDRA_CONTACT_POINTS=cassandra
       - KONG_PG_HOST=postgres
+      - PONGO_COMMAND=${ACTION}
     networks:
       - ${NETWORK_NAME}
     volumes:

--- a/pongo.sh
+++ b/pongo.sh
@@ -534,6 +534,7 @@ function compose {
   export SERVICE_NETWORK_NAME
   export KONG_TEST_IMAGE
   export PONGO_WD
+  export ACTION
   # shellcheck disable=SC2086  # we need DOCKER_COMPOSE_FILES to be word-split here
   docker-compose -p "${PROJECT_NAME}" ${DOCKER_COMPOSE_FILES} "$@"
 }
@@ -670,7 +671,7 @@ function get_plugin_names {
 function do_prerun_script {
   if [[ -f .pongo/pongo-setup-host.sh ]]; then
     # shellcheck disable=SC1091  # not following sourced script
-    .pongo/pongo-setup-host.sh
+    PONGO_COMMAND="$ACTION" .pongo/pongo-setup-host.sh
 
     if [[ $? -ne 0 ]]; then
       err "prerun script '.pongo/pongo-setup-host.sh' failed"


### PR DESCRIPTION
env var PONGO_COMMAND will get the command being executed. This allows
to customize the setup scripts to do different things on
`shell` than on `run` for example.