### PR TITLE
fix(pongo.sh) docker-compose does not have -v flag any more

### DIFF
--- a/pongo.sh
+++ b/pongo.sh
@@ -81,7 +81,7 @@ function check_tools {
     missing=true
   fi
 
-  docker-compose -v > /dev/null 2>&1
+  docker-compose > /dev/null 2>&1
   if [[ ! $? -eq 0 ]]; then
     >&2 echo "'docker-compose' command not found, please install docker-compose, and make it available in the path."
     missing=true


### PR DESCRIPTION
I don't exactly know when this change happened, but on my recently
installed docker,

```
$ docker -v
Docker version 20.10.8, build 3967b7d
```

When I execute `docker-compose -v`, it does not understand the `-v`
flag:

```
$ docker-compose -v
unknown shorthand flag: 'v' in -v
```

As a result this test in pongo always fails.

The fix should make the test pass as long as there is an executable
named `docker-compose` in the path, making this change forwards and
backwards compatible, hopefully.