### PR TITLE
fix(windows) make it work on MINGW bash

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ pongo down
 
 ## Pongo on Windows
 
+Beta: Pongo should run in Git-BASH if you have [Git for Windows](https://gitforwindows.org/)
+installed (and Docker for Windows). Please report any issues.
+
 To run Pongo on Windows you can use [WSL2](https://docs.microsoft.com/windows/wsl/)
 (Windows Subsystem for Linux).
 

--- a/pongo.sh
+++ b/pongo.sh
@@ -644,6 +644,10 @@ function build_image {
   msg "starting build of image '$KONG_TEST_IMAGE'"
   docker build \
     -f "$DOCKER_FILE" \
+    --build-arg http_proxy \
+    --build-arg https_proxy \
+    --build-arg ftp_proxy \
+    --build-arg no_proxy \
     --build-arg KONG_BASE="$KONG_IMAGE" \
     --build-arg KONG_DEV_FILES="./kong-versions/$VERSION/kong" \
     --tag "$KONG_TEST_IMAGE" \


### PR DESCRIPTION
Several issues with MINGW;

- realpath does not resolve symlinks, but returns the link
- paths need to be prefixed with //, as in '//bin/sh' and '//kong-plugin'
- terminal output should pass through 'winpty' (but pipes not)
- use powershell to open a browser window

Manually tested on `git-bash` that ships with `git` for Windows.

NOTE: also adds proxy settings to the build container (first commit)