### PR TITLE
fix(run) expose kong alias, same as with 'shell'

### DIFF
--- a/pongo.sh
+++ b/pongo.sh
@@ -1004,7 +1004,7 @@ function main {
 
     do_prerun_script
 
-    compose run --rm \
+    compose run --rm --use-aliases \
       -e KONG_LICENSE_DATA \
       -e KONG_TEST_DONT_CLEAN \
       kong \


### PR DESCRIPTION
if not exposing it, the name `kong` does not resolve to
the kong test container.