### PR TITLE
feat(plugin) ensure plugin is removed before install deps

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -12,6 +12,9 @@ COPY assets/busted_helper.lua /kong/bin
 # add new entrypoint for plugin testing
 COPY assets/test_plugin_entrypoint.sh /kong/bin/test_plugin_entrypoint.sh
 
+# add default setup script
+COPY assets/default-pongo-setup.sh /default-pongo-setup.sh
+
 # add packer script
 COPY assets/pongo_pack /kong/bin/pongo_pack
 

--- a/assets/default-pongo-setup.sh
+++ b/assets/default-pongo-setup.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# if no file `.pongo/pongo-setup.sh` is found, then this file contains
+# the default setup actions.
+
+cd /kong-plugin || { echo "Failure to enter /kong-plugin"; exit 1; }
+
+# loop over all rockspecs found
+# shellcheck disable=SC2044  #rockspecs do not contain spaces anyway
+for rockspec in $(find /kong-plugin -maxdepth 1 -type f -name '*.rockspec'); do
+  rockname=$(echo "$rockspec" | sed "s/\/kong-plugin\///" | sed "s/-[0-9a-zA-Z.]*-[0-9].rockspec//")
+  # remove the rock if another version is already installed
+  if luarocks list | grep "^$rockname$" ; then
+    luarocks remove --force "$rockname"
+  fi
+  # install any required dependencies
+  luarocks install --only-deps "$rockspec"
+done
+

--- a/assets/test_plugin_entrypoint.sh
+++ b/assets/test_plugin_entrypoint.sh
@@ -90,8 +90,12 @@ else
   pongo_setup=none
 fi
 if [ "$pongo_setup" = "none" ]; then
-  # if there is a rockspec, then install it first, so we get any required
-  # dependencies installed before testing
+  # if there is a rockspec,
+  #   1) determine the package name and uninstall it first to ensure depedency
+  #      updates can be applied
+  find /kong-plugin -maxdepth 1 -type f -name '*.rockspec' -exec awk -F "=" '/package/ {print $2}' {} \; | tr -d '"' | xargs luarocks remove
+  #   2) install the rockspec so we get any required dependencies installed
+  #      before testing
   find /kong-plugin -maxdepth 1 -type f -name '*.rockspec' -exec luarocks install --only-deps {} \;
 else
   old_entry_pwd=$(pwd)

--- a/assets/test_plugin_entrypoint.sh
+++ b/assets/test_plugin_entrypoint.sh
@@ -87,24 +87,15 @@ elif [ -f /kong-plugin/.pongo-setup.sh ]; then
   # for backward compatibility
   pongo_setup=/kong-plugin/.pongo-setup.sh
 else
-  pongo_setup=none
+  # fallback to default setup
+  pongo_setup=/default-pongo-setup.sh
 fi
-if [ "$pongo_setup" = "none" ]; then
-  # if there is a rockspec,
-  #   1) determine the package name and uninstall it first to ensure depedency
-  #      updates can be applied
-  find /kong-plugin -maxdepth 1 -type f -name '*.rockspec' -exec awk -F "=" '/package/ {print $2}' {} \; | tr -d '"' | xargs luarocks remove
-  #   2) install the rockspec so we get any required dependencies installed
-  #      before testing
-  find /kong-plugin -maxdepth 1 -type f -name '*.rockspec' -exec luarocks install --only-deps {} \;
-else
-  old_entry_pwd=$(pwd)
-  cd /kong-plugin || { echo "Failure to enter /kong-plugin"; exit 1; }
-  # shellcheck source=/dev/null  # not checking this since it is user provided
-  . $pongo_setup
-  cd "$old_entry_pwd" || { echo "Failure to enter $old_entry_pwd"; exit 1; }
-  unset old_entry_pwd
-fi
+old_entry_pwd=$(pwd)
+cd /kong-plugin || { echo "Failure to enter /kong-plugin"; exit 1; }
+# shellcheck source=/dev/null  # not checking this since it is user provided
+. $pongo_setup
+cd "$old_entry_pwd" || { echo "Failure to enter $old_entry_pwd"; exit 1; }
+unset old_entry_pwd
 unset pongo_setup
 
 


### PR DESCRIPTION
This will ensure that any plugin which has a dependency change can be properly applied and does not require the removal of older dependencies because they are still being used by any current version of the plugin installed inside the base images.

Example of issue and why this solves things:

```
Missing dependencies for kong-plugin-test 0.0.2-0:
   lua-dependency-lib 0.1.0 (not installed)

kong-plugin-test 0.0.2-0 depends on lua-dependency-lib 0.1.0 (not installed)
Installing https://luarocks.org/lua-dependency-lib-0.1.0-0.src.rock

lua-dependency-lib 0.1.0-0 depends on lua 5.1 (5.1-1 provided by VM)
lua-dependency-lib 0.1.0-0 is now installed in /usr/local (license: BSD)

Checking stability of dependencies in the absence of
lua-dependency-lib 0.0.2-0...

Will not remove lua-dependency-lib 0.0.2-0.
Removing it would break dependencies for:
kong-plugin-test 0.0.1-0

Use --force to force removal (warning: this may break modules).

lua-dependency-lib 0.0.2-0 depends on lua 5.1 (5.1-1 provided by VM)
Stopping after installing dependencies for kong-plugin-test 0.0.2-0
```

As you can see in the above output example, the older version of the made up library `lua-dependency-lib` is still installed and will be used in the plugin `test`. This commit fixes the issue for already installed plugins where pongo is used to test these changes.