### PR TITLE
fix(deps) fixed bcrypt lua module compilation

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -28,7 +28,7 @@ USER root
 # But that means hardcoding and that doesn't play well with the nature of Pongo
 # that should be independent of Kong versions.
 RUN apk update \
-    && apk add zip unzip make g++ py-pip jq git bsd-compat-headers m4 openssl-dev curl \
+    && apk add zip unzip make g++ py-pip jq git bsd-compat-headers m4 openssl-dev curl linux-headers \
     && curl -k -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin \
     && pip install httpie \
     ; cd /kong \


### PR DESCRIPTION
Building latest docker container has an error when trying to compile bcrypt Lua 

```
bcrypt 2.1-6 depends on lua >= 5.1 (5.1-1 provided by VM)
Warning: variable CFLAGS was not passed in build_variables
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG -O0 -c -o compat/safebfuns.o compat/safebfuns.c
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o compat/bcrypt/bcrypt.o compat/bcrypt/bcrypt.c
compat/bcrypt/bcrypt.c: In function 'bcrypt_hashpass':
compat/bcrypt/bcrypt.c:185:37: warning: 'snprintf' output may be truncated before the last format character [-Wformat-truncation=]
  185 |  snprintf(encrypted, 8, "$2%c$%2.2u$", minor, logr);
      |                                     ^
compat/bcrypt/bcrypt.c:185:2: note: 'snprintf' output between 8 and 9 bytes into a destination of size 8
  185 |  snprintf(encrypted, 8, "$2%c$%2.2u$", minor, logr);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o compat/bcrypt/blowfish.o compat/bcrypt/blowfish.c
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o compat/arc4random/arc4random.o compat/arc4random/arc4random.c
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o compat/sha/sha512.o compat/sha/sha512.c
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o compat/getentropy/getentropy_linux.o compat/getentropy/getentropy_linux.c
compat/getentropy/getentropy_linux.c:52:10: fatal error: linux/types.h: No such file or directory
   52 | #include <linux/types.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
make: *** [<builtin>: compat/getentropy/getentropy_linux.o] Error 1

Error: Failed installing dependency: https://luarocks.org/bcrypt-2.1-6.src.rock - Build error: Failed building.
Kong version: Kong Enterprise 2.6.0.0-dev
```


After the fix

```

bcrypt 2.1-6 depends on lua >= 5.1 (5.1-1 provided by VM)
Warning: variable CFLAGS was not passed in build_variables
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG -O0 -c -o compat/safebfuns.o compat/safebfuns.c
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o compat/bcrypt/bcrypt.o compat/bcrypt/bcrypt.c
compat/bcrypt/bcrypt.c: In function 'bcrypt_hashpass':
compat/bcrypt/bcrypt.c:185:37: warning: 'snprintf' output may be truncated before the last format character [-Wformat-truncation=]
  185 |  snprintf(encrypted, 8, "$2%c$%2.2u$", minor, logr);
      |                                     ^
compat/bcrypt/bcrypt.c:185:2: note: 'snprintf' output between 8 and 9 bytes into a destination of size 8
  185 |  snprintf(encrypted, 8, "$2%c$%2.2u$", minor, logr);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o compat/bcrypt/blowfish.o compat/bcrypt/blowfish.c
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o compat/arc4random/arc4random.o compat/arc4random/arc4random.c
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o compat/sha/sha512.o compat/sha/sha512.c
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o compat/getentropy/getentropy_linux.o compat/getentropy/getentropy_linux.c
gcc -I/usr/local/openresty/luajit/include/luajit-2.1 -DOPENSSL_cleanse=explicit_bzero -Icompat/include -Wall -Wno-pointer-sign -O2 -fPIC -DNDEBUG   -c -o src/main.o src/main.c
src/main.c:24: warning: "luaL_newlib" redefined
   24 |  #define luaL_newlib( L, l ) ( lua_newtable( L ), luaL_register( L, NULL, l ) )
      |
In file included from src/main.c:21:
/usr/local/openresty/luajit/include/luajit-2.1/lauxlib.h:125: note: this is the location of the previous definition
  125 | #define luaL_newlib(L, l) (luaL_newlibtable(L, l), luaL_setfuncs(L, l, 0))
      |
gcc -o bcrypt.so compat/safebfuns.o compat/bcrypt/bcrypt.o compat/bcrypt/blowfish.o compat/arc4random/arc4random.o compat/sha/sha512.o compat/getentropy/getentropy_linux.o src/main.o -shared -lrt
bcrypt 2.1-6 is now installed in /usr/local (license: ISC)

kong 2.6.0-0 depends on lpeg_patterns 0.5 (0.5-0 installed)
kong 2.6.0-0 depends on http 0.3 (not installed)
Installing https://luarocks.org/http-0.3-0.src.rock

http 0.3-0 depends on lua >= 5.1 (5.1-1 provided by VM)
http 0.3-0 depends on compat53 >= 0.3 (0.8-1 installed)
http 0.3-0 depends on bit32 (5.3.5.1-1 installed)
http 0.3-0 depends on cqueues >= 20161214 (20200726.51-0 installed)
http 0.3-0 depends on luaossl >= 20161208 (20200709-0 installed)
http 0.3-0 depends on basexx >= 0.2.0 (0.4.1-1 installed)
http 0.3-0 depends on lpeg (1.0.2-1 installed)
http 0.3-0 depends on lpeg_patterns >= 0.5 (0.5-0 installed)
http 0.3-0 depends on binaryheap >= 0.3 (0.4-1 installed)
http 0.3-0 depends on fifo (0.2-0 installed)
http 0.3-0 is now installed in /usr/local (license: MIT)

Checking stability of dependencies in the absence of
http 0.4-0...

Removing http 0.4-0...
Removal successful.
kong 2.6.0-0 depends on lua-resty-worker-events 1.0.0 (1.0.0-1 installed)
kong 2.6.0-0 depends on lua-resty-healthcheck 1.4.2 (1.4.2-1 installed)
kong 2.6.0-0 depends on lua-resty-cookie 0.1.0 (0.1.0-1 installed)
kong 2.6.0-0 depends on lua-resty-mlcache 2.5.0 (2.5.0-1 installed)
kong 2.6.0-0 depends on lua-messagepack 0.5.2 (0.5.2-1 installed)
kong 2.6.0-0 depends on lua-resty-openssl 0.8.1 (not installed)
Installing https://luarocks.org/lua-resty-openssl-0.8.1-1.src.rock

lua-resty-openssl 0.8.1-1 is now installed in /usr/local (license: BSD)

Checking stability of dependencies in the absence of
lua-resty-openssl 0.7.4-1...

Removing lua-resty-openssl 0.7.4-1...
Removal successful.
kong 2.6.0-0 depends on lua-resty-counter 0.2.1 (0.2.1-1 installed)
kong 2.6.0-0 depends on lua-resty-template 1.9 (not installed)
Installing https://luarocks.org/lua-resty-template-1.9-1.src.rock

lua-resty-template 1.9-1 depends on lua >= 5.1 (5.1-1 provided by VM)
lua-resty-template 1.9-1 is now installed in /usr/local (license: BSD)

kong 2.6.0-0 depends on lua-resty-passwdqc 1.1 (not installed)
Installing https://luarocks.org/lua-resty-passwdqc-1.1-1.src.rock

lua-resty-passwdqc 1.1-1 depends on lua >= 5.1 (5.1-1 provided by VM)
lua-resty-passwdqc 1.1-1 is now installed in /usr/local (license: BSD)

kong 2.6.0-0 depends on lua-resty-ipmatcher 0.6.1 (0.6.1-0 installed)
kong 2.6.0-0 depends on lua-resty-acme 0.7.2 (not installed)
Installing https://luarocks.org/lua-resty-acme-0.7.2-1.src.rock

lua-resty-acme 0.7.2-1 depends on lua-resty-http >= 0.15-0 (0.16.1-0 installed)
lua-resty-acme 0.7.2-1 depends on lua-resty-lrucache >= 0.09-2 (0.09-2 installed)
lua-resty-acme 0.7.2-1 depends on lua-resty-openssl >= 0.7.0 (0.8.1-1 installed)
lua-resty-acme 0.7.2-1 is now installed in /usr/local (license: BSD)

Checking stability of dependencies in the absence of
lua-resty-acme 0.7.1-1...

Removing lua-resty-acme 0.7.1-1...
Removal successful.
kong 2.6.0-0 depends on lua-resty-session 3.8 (3.8-1 installed)
kong 2.6.0-0 depends on kong-plugin-azure-functions ~> 1.0 (1.0.1-1 installed)
kong 2.6.0-0 depends on kong-plugin-zipkin ~> 1.4 (1.4.1-1 installed)
kong 2.6.0-0 depends on kong-plugin-request-transformer ~> 1.3 (1.3.2-0 installed)
Stopping after installing dependencies for kong 2.6.0-0

Kong version: Kong Enterprise 2.6.0.0-dev
```