### PR TITLE
feat(pongo): Expose more environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ Environment variables:
   CASSANDRA     the version of the Cassandra dependency to use (default 3.9)
   REDIS         the version of the Redis dependency to use (default 5.0.4)
 
+  PONGO_DOCKER_FILE
+                the dockerfile used to build the pongo testing image
+  PONGO_DOCKER_COMPOSE_FILE
+                the compose file used to run the pongo test harness
+  PONGO_DOCKER_COMPOSE_PROJECT_NAME
+                the compose project name to use (default kong-pongo)
+  PONGO_DOCKER_COMPOSE_NETWORK_NAME
+                the compose network to create (default: pongo-test-network)
+  PONGO_FORCE_BUILD
+                force a rebuild of the pongo test image when using the `build` command
+
+
 Example usage:
   pongo run
   KONG_VERSION=1.3.x pongo run -v -o gtest ./spec/02-access_spec.lua
@@ -746,7 +758,8 @@ _**WARNING**: make sure to read up on the security consequences this has! You ar
 
 ### A walkthrough
 
-1. Start a container to run Pongo;
+NGO
+1. Start a container to run Pongo ;
 
         docker run -it --rm \
           -v /var/run/docker.sock:/var/run/docker.sock \

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -98,7 +98,6 @@ cd "$old_entry_pwd" || { echo "Failure to enter $old_entry_pwd"; exit 1; }
 unset old_entry_pwd
 unset pongo_setup
 
-
 if [ ! "$SUPPRESS_KONG_VERSION" = "true" ]; then
   echo "Kong version: $(kong version)"
 fi

--- a/pongo.sh
+++ b/pongo.sh
@@ -8,10 +8,10 @@ function globals {
   # explicitly resolve the link because realpath doesn't do it on Windows
   script_path=$(test -L "$0" && readlink "$0" || echo "$0")
   LOCAL_PATH=$(dirname "$(realpath "$script_path")")
-  DOCKER_FILE=${LOCAL_PATH}/assets/Dockerfile
-  DOCKER_COMPOSE_FILES="-f ${LOCAL_PATH}/assets/docker-compose.yml"
-  PROJECT_NAME=kong-pongo
-  NETWORK_NAME=pongo-test-network
+  DOCKER_FILE=${PONGO_DOCKER_FILE:-$LOCAL_PATH/assets/Dockerfile}
+  DOCKER_COMPOSE_FILES="-f ${PONGO_DOCKER_COMPOSE_FILE:-$LOCAL_PATH/assets/docker-compose.yml}"
+  PROJECT_NAME=${PONGO_DOCKER_COMPOSE_PROJECT_NAME:-kong-pongo}
+  NETWORK_NAME=${PONGO_DOCKER_COMPOSE_NETWORK_NAME:-pongo-test-network}
   SERVICE_NETWORK_NAME=${PROJECT_NAME}
   IMAGE_BASE_NAME=${PROJECT_NAME}-test
   KONG_TEST_PLUGIN_PATH=$(realpath .)
@@ -70,7 +70,7 @@ function globals {
 
   # Commandline related variables
   unset ACTION
-  FORCE_BUILD=false
+  FORCE_BUILD=${PONGO_FORCE_BUILD:-false}
   KONG_DEPS_AVAILABLE=( "postgres" "cassandra" "redis" "squid" "grpcbin" "expose")
   KONG_DEPS_START=( "postgres" "cassandra" )
   KONG_DEPS_CUSTOM=()
@@ -1040,6 +1040,7 @@ function main {
     compose run --rm --use-aliases \
       -e KONG_LICENSE_DATA \
       -e KONG_TEST_DONT_CLEAN \
+      -e SUPPRESS_KONG_VERSION \
       kong \
       "$WINDOWS_SLASH/bin/sh" "-c" "bin/busted --helper=$WINDOWS_SLASH/pongo/busted_helper.lua ${busted_params[*]} ${busted_files[*]}"
     ;;


### PR DESCRIPTION
Adds several environment variable hooks to allow better control over the
docker + compose setup when running compose

*  PONGO_DOCKER_FILE - the dockerfile used to build the pongo testing image
*  PONGO_DOCKER_COMPOSE_FILE - the compose file used to run the pongo test harness
*  PONGO_DOCKER_COMPOSE_PROJECT_NAME - the compose project name to use (default kong-pongo)
*  PONGO_DOCKER_COMPOSE_NETWORK_NAME - the compose network to create (default: pongo-test-network)
*  PONGO_FORCE_BUILD - force a rebuild of the pongo test image when using the `build` command