### PR TITLE
fix(clean) run a prune command to clear the build cache

### DIFF
--- a/pongo.sh
+++ b/pongo.sh
@@ -736,6 +736,9 @@ function pongo_clean {
     docker rmi $(docker images --filter=reference="pongo-expose:*" --format "{{.ID}}")
   fi
 
+  # prune to prevent rebuilding to happen from the docker build cache
+  docker builder prune -f
+
   if [ -d "$LOCAL_PATH/kong" ]; then
     rm -rf "$LOCAL_PATH/kong"
   fi


### PR DESCRIPTION
If not pruning the build cache, the next run will simply rebuild
the images from the cache without actually rebuilding. In case of
a `pongo clean` or `pongo nuke` that's not what we want.

See #188 #94 #189 