### PR TITLE
fix(dns) remove hardcoded DNS nameserver

### DIFF
--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -120,8 +120,8 @@ services:
   kong:
     image: ${KONG_TEST_IMAGE:-ignore_if_not_provided}
     environment:
-      - KONG_CASSANDRA_CONTACT_POINTS=cassandra
-      - KONG_PG_HOST=postgres
+      - KONG_CASSANDRA_CONTACT_POINTS=${SERVICE_NETWORK_NAME}_cassandra_1.${SERVICE_NETWORK_NAME}
+      - KONG_PG_HOST=${SERVICE_NETWORK_NAME}_postgres_1.${SERVICE_NETWORK_NAME}
       - PONGO_COMMAND=${ACTION}
     networks:
       - ${NETWORK_NAME}

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -36,10 +36,6 @@ fi
 # add the plugin code to the LUA_PATH such that the plugin will be found
 export "LUA_PATH=/kong-plugin/?.lua;/kong-plugin/?/init.lua;;"
 
-# DNS resolution on docker always has this ip. Since we have a qualified
-# name for the db server, we need to set up the DNS resolver, is set
-# to 8.8.8.8 on the spec conf
-export KONG_DNS_RESOLVER=127.0.0.11
 
 # set working dir in mounted volume to be able to check the logs
 export KONG_PREFIX=/kong-plugin/servroot


### PR DESCRIPTION
The docker dns resolver is needed to find local dependencies. But there are some hardcoded settings preventing this.

- entrypoint sets the resolver to the standard docker resolver `127.0.0.11` but this doesn't always work
- unsetting the dnsresolver has issues because the Kong test spec (in the test artifacts from the test/dev scaffolding) hardcodes it to `8.8.8.8`.
- there is no easy way to "unset" the `8.8.8.8` resolver in the conf files

Option;
Parse the `/etc/resolv.conf` in the entrypoint, get the nameservers listed, and set them in `KONG_DNS_RESOLVER`