### PR TITLE
feat(deps) allow imagenames instead of only versions

### DIFF
--- a/assets/ci/pongo_docker.test.sh
+++ b/assets/ci/pongo_docker.test.sh
@@ -19,10 +19,10 @@ function run_test {
 
   ttest "build.sh builds a Pongo image"
   ../docker/build.sh
-  if [ $? -eq 1 ]; then
-    tfailure
-  else
+  if [ $? -eq 0 ]; then
     tsuccess
+  else
+    tfailure
   fi
 
   tmessage "setup: clone test plugin and enter directory"

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - ${NETWORK_NAME}
 
   postgres:
-    image: postgres:${POSTGRES:-9.5}
+    image: ${POSTGRES_IMAGE:-postgres:9.5}
     environment:
       POSTGRES_USER: kong
       POSTGRES_DB: kong_tests
@@ -64,7 +64,7 @@ services:
       - ${NETWORK_NAME}
 
   cassandra:
-    image: cassandra:${CASSANDRA:-3.9}
+    image: ${CASSANDRA_IMAGE:-cassandra:3.9}
     environment:
       MAX_HEAP_SIZE: 256M
       HEAP_NEWSIZE: 128M
@@ -79,7 +79,7 @@ services:
       - ${NETWORK_NAME}
 
   redis:
-    image: redis:${REDIS:-5.0.4}-alpine
+    image: ${REDIS_IMAGE:-redis:5.0.4-alpine}
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -91,7 +91,7 @@ services:
       - ${NETWORK_NAME}
 
   squid:
-    image: sameersbn/squid:${SQUID:-3.5.27-2}
+    image: ${SQUID_IMAGE:-sameersbn/squid:3.5.27-2}
     volumes:
       - ./squid/squid.conf:/etc/squid/squid.conf
       - ./squid/passwords:/etc/squid/passwords
@@ -106,7 +106,7 @@ services:
       - ${NETWORK_NAME}
 
   grpcbin:
-    image: moul/grpcbin:latest
+    image: ${GRPCBIN_IMAGE:-moul/grpcbin:latest}
     healthcheck:
       interval: 5s
       retries: 10

--- a/assets/help/pongo.txt
+++ b/assets/help/pongo.txt
@@ -56,13 +56,14 @@ Environment variables:
   KONG_LICENSE_DATA
                 set this variable with the Kong Enterprise license data
 
-  POSTGRES      the version of the Postgres dependency to use (default 9.5)
-  CASSANDRA     the version of the Cassandra dependency to use (default 3.9)
-  REDIS         the version of the Redis dependency to use (default 5.0.4)
-  SQUID         the version of the Squid dependency to use (default 3.5.27-2)
+  POSTGRES_IMAGE   the Postgres image to use (default postgres:9.5)
+  CASSANDRA_IMAGE  the Cassandra image to use (default cassandra:3.9)
+  REDIS_IMAGE      the Redis dependency to use (default redis:5.0.4-alpine)
+  SQUID_IMAGE      the Squid dependency to use (default sameersbn/squid:3.5.27-2)
+  GRPCBIN_IMAGE    the Grpcbin dependency to use (default moul/grpcbin:latest)
 
 Example usage:
   pongo run
   KONG_VERSION=1.3.x pongo run -v -o gtest ./spec/02-access_spec.lua
-  POSTGRES=10 KONG_IMAGE=kong-ee pongo run
+  POSTGRES_IMAGE=postgres:10 KONG_IMAGE=kong-ee pongo run
   pongo down

--- a/assets/help/run.txt
+++ b/assets/help/run.txt
@@ -43,4 +43,4 @@ Example usage:
   pongo run
   KONG_VERSION=nightly pongo run
   KONG_VERSION=1.3.x pongo run -v -o TAP ./spec/02-access_spec.lua
-  POSTGRES=10 KONG_IMAGE=kong-ee pongo run
+  POSTGRES_IMAGE=postgres:10 KONG_IMAGE=kong-ee pongo run

--- a/assets/help/up.txt
+++ b/assets/help/up.txt
@@ -27,10 +27,11 @@ Default available dependencies:
 
 
 Environment variables:
-  POSTGRES      the version of the Postgres dependency to use (default 9.5)
-  CASSANDRA     the version of the Cassandra dependency to use (default 3.9)
-  REDIS         the version of the Redis dependency to use (default 5.0.4)
-  SQUID         the version of the Squid dependency to use (default 3.5.27-2)
+  POSTGRES_IMAGE   the Postgres image to use (default postgres:9.5)
+  CASSANDRA_IMAGE  the Cassandra image to use (default cassandra:3.9)
+  REDIS_IMAGE      the Redis dependency to use (default redis:5.0.4-alpine)
+  SQUID_IMAGE      the Squid dependency to use (default sameersbn/squid:3.5.27-2)
+  GRPCBIN_IMAGE    the Grpcbin dependency to use (default moul/grpcbin:latest)
 Custom dependencies may have their own variables.
 
 

--- a/pongo.sh
+++ b/pongo.sh
@@ -115,6 +115,29 @@ function globals {
   # Nightly CE images, these are public, no credentials needed
   NIGHTLY_CE_TAG="kong/kong:latest"
 
+
+  # Dependency image defaults
+  if [[ -z $POSTGRES_IMAGE ]] && [[ -n $POSTGRES ]]; then
+    # backward compat; POSTGRES replaced by POSTGRES_IMAGE
+    export POSTGRES_IMAGE=postgres:$POSTGRES
+  fi
+
+  if [[ -z $CASSANDRA_IMAGE ]] && [[ -n $CASSANDRA ]]; then
+    # backward compat; CASSANDRA replaced by CASSANDRA_IMAGE
+    export CASSANDRA_IMAGE=cassandra:$CASSANDRA
+  fi
+
+  if [[ -z $REDIS_IMAGE ]] && [[ -n $REDIS ]]; then
+    # backward compat; replaced by REDIS_IMAGE
+    export REDIS_IMAGE=redis:$REDIS-alpine
+  fi
+
+  if [[ -z $SQUID_IMAGE ]] && [[ -n $SQUID ]]; then
+    # backward compat; replaced by SQUID_IMAGE
+    export SQUID_IMAGE=sameersbn/squid:$SQUID
+  fi
+
+
   # Commandline related variables
   unset ACTION
   FORCE_BUILD=false


### PR DESCRIPTION
In closed down environments not all images are available, and
others must be able to be specified.