### PR TITLE
chore(cassandra) upgrade to 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Environment variables:
                 set this variable with the Kong Enterprise license data
 
   POSTGRES      the version of the Postgres dependency to use (default 9.5)
-  CASSANDRA     the version of the Cassandra dependency to use (default 3.9)
+  CASSANDRA     the version of the Cassandra dependency to use (default 3.11)
   REDIS         the version of the Redis dependency to use (default 5.0.4)
 
 Example usage:

--- a/README.md
+++ b/README.md
@@ -777,6 +777,9 @@ The result should be a new PR on the Pongo repo.
 
 ### unreleased
 
+ * Upgrade cassandra image from 3.9 to 3.11 for M1 chip
+   [#269](https://github.com/Kong/kong-pongo/pull/269)
+
  * Fix rock installation issue due to unauthenticated Git protocol
    [#266](https://github.com/Kong/kong-pongo/pull/266)
 

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -66,7 +66,7 @@ services:
           - ${SERVICE_NETWORK_NAME}-postgres.${SERVICE_NETWORK_NAME}
 
   cassandra:
-    image: ${CASSANDRA_IMAGE:-cassandra:3.9}
+    image: ${CASSANDRA_IMAGE:-cassandra:3.11}
     environment:
       MAX_HEAP_SIZE: 256M
       HEAP_NEWSIZE: 128M

--- a/assets/help/pongo.txt
+++ b/assets/help/pongo.txt
@@ -57,7 +57,7 @@ Environment variables:
                 set this variable with the Kong Enterprise license data
 
   POSTGRES_IMAGE   the Postgres image to use (default postgres:9.5)
-  CASSANDRA_IMAGE  the Cassandra image to use (default cassandra:3.9)
+  CASSANDRA_IMAGE  the Cassandra image to use (default cassandra:3.11)
   REDIS_IMAGE      the Redis dependency to use (default redis:5.0.4-alpine)
   SQUID_IMAGE      the Squid dependency to use (default sameersbn/squid:3.5.27-2)
   GRPCBIN_IMAGE    the Grpcbin dependency to use (default moul/grpcbin:latest)

--- a/assets/help/up.txt
+++ b/assets/help/up.txt
@@ -28,7 +28,7 @@ Default available dependencies:
 
 Environment variables:
   POSTGRES_IMAGE   the Postgres image to use (default postgres:9.5)
-  CASSANDRA_IMAGE  the Cassandra image to use (default cassandra:3.9)
+  CASSANDRA_IMAGE  the Cassandra image to use (default cassandra:3.11)
   REDIS_IMAGE      the Redis dependency to use (default redis:5.0.4-alpine)
   SQUID_IMAGE      the Squid dependency to use (default sameersbn/squid:3.5.27-2)
   GRPCBIN_IMAGE    the Grpcbin dependency to use (default moul/grpcbin:latest)


### PR DESCRIPTION
https://hub.docker.com/_/cassandra?tab=tags&page=1&name=3.9

Image `cassandra:3.9` does not support architecture `arm/v8` (M1 chip), perhaps we need to upgrade to `cassandra:3.11` to support it.