### PR TITLE
chore(docs) add update instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ ln -s $(realpath kong-pongo/pongo.sh) ~/.local/bin/pongo
 
 ## Update
 
-Since the shell script is symbolic linked to ~/.local/bin/pongo, in order to update the program, all you have to do is to fetch latest changes from this repo:
+Since the Pongo script is symbolic linked to `~/.local/bin/pongo`, in order to update Pongo, all you have to do is to fetch latest changes from the Pongo repo:
 
 ```
 cd <repo cloned directory>

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Pongo provides a simple way of testing Kong plugins
 
  - [Requirements](#requirements)
  - [Installation](#installation)
+ - [Update](#update)
  - [Configuration](#configuration)
  - [Do a test run](#do-a-test-run)
  - [Pongo on Windows](#pongo-on-windows)
@@ -140,6 +141,15 @@ PATH=$PATH:~/.local/bin
 git clone https://github.com/Kong/kong-pongo.git
 mkdir -p ~/.local/bin
 ln -s $(realpath kong-pongo/pongo.sh) ~/.local/bin/pongo
+```
+
+## Update
+
+Since the shell script is symbolic linked to ~/.local/bin/pongo, in order to update the program, all you have to do is to fetch latest changes from this repo:
+
+```
+cd <repo cloned directory>
+git pull
 ```
 
 [Back to ToC](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ ln -s $(realpath kong-pongo/pongo.sh) ~/.local/bin/pongo
 Since the Pongo script is symbolic linked to `~/.local/bin/pongo`, in order to update Pongo, all you have to do is to fetch latest changes from the Pongo repo:
 
 ```
-cd <repo cloned directory>
+cd <cloned Pongo repo>
 git pull
 ```
 


### PR DESCRIPTION
Since the kong docker image used is directly tied to the version configured in the repository, pulling latest changes form this repo is one of the easiest ways of getting latest code. So added this missing piece of information right below Installation.