### PR TITLE
fix(deps) install wget as well

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -28,7 +28,7 @@ USER root
 # But that means hardcoding and that doesn't play well with the nature of Pongo
 # that should be independent of Kong versions.
 RUN apk update \
-    && apk add zip unzip make g++ py-pip jq git bsd-compat-headers m4 openssl-dev curl python3-dev \
+    && apk add zip unzip make g++ py-pip jq git bsd-compat-headers m4 openssl-dev curl wget python3-dev \
     && curl -k -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin \
     && pip install httpie \
     ; cd /kong \


### PR DESCRIPTION
With FIPS build, we are dropping luasec in the container(on both FIPS
and non-FIPS build), as it's only used in development; it's now moved
to a dev dependency
(https://github.com/Kong/kong-ee/commit/d0c789d2812a645390f18b2f7a4b1f55acc9a6ea).

With that removed, luarocks fallbacks to wget. On Alpine,
wget comes with busybox doesn't understand `--timestamp` and cause
all dependencies failed to install.