### PR TITLE
chore(versions) add support for EE 3.0.0+ versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 kong-versions/nightly-ee/*
 kong-versions/nightly/*
 servroot
+.vscode
+/kong/
+/kong-ee/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 install:
 	mkdir -p ~/.local/bin
 	ln -sf $$(pwd)/pongo.sh ~/.local/bin/pongo
-	if [ ! "$$(command -v pongo)" = "$$(command -v ~/.local/bin/pongo)" ]; then \
-		echo -e "\033[0;33m[INFO] please add ~/.local/bin/ to your system path \033[0m"; \
-		echo -e "\033[0;33m[INFO]    export PATH=~/.local/bin/:"'$$'"PATH\033[0m"; \
+	@if [ ! "$$(command -v pongo)" = "$$(command -v ~/.local/bin/pongo)" ]; then \
+		echo "\033[0;33m[INFO] please add ~/.local/bin/ to your system path \033[0m"; \
+		echo "\033[0;33m[INFO]    export PATH=~/.local/bin/:"'$$'"PATH\033[0m"; \
 	fi
 
 lint:

--- a/assets/add_version.sh
+++ b/assets/add_version.sh
@@ -60,6 +60,13 @@ if [[ "$ADD_VERSION" == "" ]]; then
   usage
   exit 1
 fi
+# for Kong Enterprise 3.0.0+ use a 'e' prefix
+if [[ "$CODE_BASE" == "EE" ]]; then
+  if [[ ${ADD_VERSION//[0-9]} == ".." ]]; then
+    # only 3 digits so a 3.0.0+ EE version
+    ADD_VERSION=e$ADD_VERSION
+  fi
+fi
 msg "Version to add: $ADD_VERSION"
 
 #TODO: here check we're in a Pongo git repo, and on 'master' branch

--- a/assets/update_versions.sh
+++ b/assets/update_versions.sh
@@ -83,12 +83,17 @@ function update_single_version_artifacts {
     local fname
 
     if [[ "$COMMIT" == "" ]]; then
-      COMMIT=$VERSION
+      if [[ ${VERSION//[0-9]} == "e.." ]]; then
+        # Kong Eneterprise version 3.0.0+; strip 'e' prefix
+        COMMIT=${VERSION:1}
+      else
+        COMMIT=$VERSION
+      fi
     fi
 
     git checkout -q "$COMMIT"
     if [ ! $? -eq 0 ]; then
-        warn "cannot checkout version $VERSION. Is the tag missing? skipping it for now..."
+        warn "cannot checkout version $COMMIT. Is the tag missing? skipping it for now..."
     else
         mkdir "../kong-versions/$VERSION"
         mkdir "../kong-versions/$VERSION/kong"


### PR DESCRIPTION
possible replacement for #286 . 

This implementation requires the user to use a 'e' prefix for the version. Changes nothing for the existing ones.

- `3.0.0` runs Kong CE 3.0.0
- `e3.0.0` runs Kong EE 3.0.0
- `2.8.0.0` runs Kong EE 2.8.0.0

This has a single element denoting the version, without requiring an explicit `--ee` flag, which makes it easier in CI matrices as well.

Untested for now.