### PR TITLE
fix(alias) start Kong if no declarative file

### DIFF
--- a/assets/kong_migrations_start.sh
+++ b/assets/kong_migrations_start.sh
@@ -13,15 +13,18 @@ elif [ -f /kong-plugin/kong.yml ]; then
     KMS_FILENAME=kong.yml
 elif [ -f /kong-plugin/kong.json ]; then
     KMS_FILENAME=kong.json
-else
-    echo 'Declarative file "kong.yaml/yml/json" not found, skipping import'
 fi
+# fi
 
-echo "Found \"$KMS_FILENAME\", importing declarative config..."
-kong config db_import /kong-plugin/$KMS_FILENAME
-if [ $? -ne 0 ]; then
-    echo "Failed to import \"$KMS_FILENAME\""
-    exit 1
+if [ "$KMS_FILENAME" = "" ]; then
+    echo 'Declarative file "kong.yaml/yml/json" not found, skipping import'
+else
+    echo "Found \"$KMS_FILENAME\", importing declarative config..."
+    kong config db_import /kong-plugin/$KMS_FILENAME
+    if [ $? -ne 0 ]; then
+        echo "Failed to import \"$KMS_FILENAME\""
+        exit 1
+    fi
 fi
 
 kong start


### PR DESCRIPTION
fix: if there was no declarative file, the import would fail and kong wouldn't be started.