### PR TITLE
chore(ci) migrate our nightlies from master-nightly-alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,9 @@ The result should be a new PR on the Pongo repo.
  * Aliases now support `.yml` and `.json` extension for declarative config file
    [#296](https://github.com/Kong/kong-pongo/pull/296)
 
+ * Changed nightly-ee image to the new `master` tag
+   [#300](https://github.com/Kong/kong-pongo/pull/300)
+
 ---
 
 ## 1.1.0 released 14-Jun-2022

--- a/pongo.sh
+++ b/pongo.sh
@@ -112,7 +112,7 @@ function globals {
 
   # Nightly EE images repo, these require to additionally set the credentials
   # in $DOCKER_USERNAME and $DOCKER_PASSWORD
-  NIGHTLY_EE_TAG="kong/kong-gateway-internal:master"
+  NIGHTLY_EE_TAG="kong/kong-gateway-internal:master-alpine"
 
   # Nightly CE images, these are public, no credentials needed
   NIGHTLY_CE_TAG="kong/kong:latest"

--- a/pongo.sh
+++ b/pongo.sh
@@ -112,7 +112,7 @@ function globals {
 
   # Nightly EE images repo, these require to additionally set the credentials
   # in $DOCKER_USERNAME and $DOCKER_PASSWORD
-  NIGHTLY_EE_TAG="kong/kong-gateway-internal:master-nightly-alpine"
+  NIGHTLY_EE_TAG="kong/kong-gateway-internal:master"
 
   # Nightly CE images, these are public, no credentials needed
   NIGHTLY_CE_TAG="kong/kong:latest"


### PR DESCRIPTION
We [now](https://github.com/Kong/kong-ee/commit/5dccd1201eff001b2ab2744f1d81758c6e0df5ce) build docker containers that are simply named after the branch so kong/kong-gateway-internal:master