### PR TITLE
feat(redis) support spec tests with redis cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,11 @@ The result should be a new PR on the Pongo repo.
 
 ## unreleased
 
+ * Enabled redis cluster tests
+   [#305](https://github.com/Kong/kong-pongo/pull/305)
+
  * Export the new `KONG_SPEC_TEST_REDIS_HOST` variable to be compatible with Kong 3.0.0+
+   [#290](https://github.com/Kong/kong-pongo/pull/290)
 
  * Aliases now support `.yml` and `.json` extension for declarative config file
    [#296](https://github.com/Kong/kong-pongo/pull/296)

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -69,6 +69,8 @@ export KONG_LOG_LEVEL=debug
 export KONG_SPEC_REDIS_HOST=redis
 # Kong test-helpers 3.0.0+
 export KONG_SPEC_TEST_REDIS_HOST=redis
+# Support Redis Cluster (RC)
+export KONG_SPEC_TEST_REDIS_CLUSTER_ADDRESSES='["rc:7000","rc:7001","rc:7003"]'
 
 # set the certificate store
 export KONG_LUA_SSL_TRUSTED_CERTIFICATE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Kong currently does not support connection to redis cluster and will
be fixed in FTI-2014.

We should support an ENV to load redis cluster seeds:
KONG_SPEC_TEST_REDIS_CLUSTER_ADDRESSES