### PR TITLE
docs(readme) fix anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Some helpfull examples:
 This section is about debugging plugin code. If you have trouble with the Pongo
 environment then check [Dependency troubleshooting](#dependency-troubleshooting).
 
-### Accessing logs
+### Accessing the logs
 
 When running the tests, the Kong prefix (or working directory) will be set to
 `./servroot`.


### PR DESCRIPTION
The anchor `Accessing the logs` in the table of contents was pointing to `accessing-the-logs` but the target was actually `accessing-logs`.