### PR TITLE
feat(redis) support spec tests with redis cluster

### DIFF
--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -70,7 +70,7 @@ export KONG_SPEC_REDIS_HOST=redis
 # Kong test-helpers 3.0.0+
 export KONG_SPEC_TEST_REDIS_HOST=redis
 # Support Redis Cluster (RC)
-export KONG_SPEC_TEST_REDIS_CLUSTER_ADDRESSES='["rc:7000","rc:7001","rc:7003"]'
+export KONG_SPEC_TEST_REDIS_CLUSTER_ADDRESSES="rc:7000,rc:7001,rc:7003"
 
 # set the certificate store
 export KONG_LUA_SSL_TRUSTED_CERTIFICATE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Kong currently does not support connection to redis cluster and will be fixed in FTI-2014.

We should support an ENV to load redis cluster seeds: KONG_SPEC_TEST_REDIS_CLUSTER_ADDRESSES