### PR TITLE
fix(mount) update permissions to ensure access

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -32,7 +32,7 @@ USER root
 # But that means hardcoding and that doesn't play well with the nature of Pongo
 # that should be independent of Kong versions.
 RUN apk update \
-    && apk add zip unzip make g++ py-pip jq git bsd-compat-headers m4 openssl-dev curl wget python3-dev \
+    && apk add zip unzip make g++ py-pip jq git bsd-compat-headers m4 openssl-dev curl wget python3-dev shadow \
     && curl -k -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin \
     && pip install httpie \
     ; cd /kong \

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -113,12 +113,12 @@ if [ -d /kong-plugin ]; then
   MOUNT_GID=$(stat -c "%g" /kong-plugin)
   if [ ! "$KONG_GID" = "$MOUNT_GID" ]; then
     # change KONG_GID to the ID of the folder owner group
-    groupmod -g "$MOUNT_GID" kong > /dev/null 2>&1
+    groupmod -g "$MOUNT_GID" --non-unique kong
   fi
 
   if [ ! "$KONG_UID" = "$MOUNT_UID" ]; then
     # change KONG_UID to the ID of the folder owner
-    usermod -u "$MOUNT_UID" -g "$MOUNT_GID" kong > /dev/null 2>&1
+    usermod -u "$MOUNT_UID" -g "$MOUNT_GID" --non-unique kong
   fi
   unset KONG_UID
   unset KONG_GID


### PR DESCRIPTION
Modify the 'kong' user to match the ownership of the mounted plugin folder. Kong will not start because of permission errors if it cannot write to the /kong-plugin/servroot folder (which resides on the mount). Since those permissions are controlled by the host, we update the 'kong' user inside the container to match the UID and GID.