### PR TITLE
deps(cassandra) cassandra no longer started by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ To modify the default behaviour there are 2 scripts that can be hooked up:
   The interpreter can be set using the regular shebang.
 
 * `.pongo/pongo-setup.sh` is ran upon container start **inside** the Kong
-  container. It will not be executed but sourced, and will run on `/bin/sh` as
+  container. It will not be executed but sourced, and will run on `/bin/bash` as
   interpreter.
 
 Both scripts will have an environment variable `PONGO_COMMAND` that will have
@@ -555,7 +555,7 @@ fi
 
 Example `.pongo/pongo-setup.sh`:
 ```shell
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # this runs in the test container upon starting it
 cd /kong-plugin/my_dependency
@@ -800,20 +800,29 @@ The result should be a new PR on the Pongo repo.
 
 ## unreleased 2.x
 
-### Upgrade steps
+#### Upgrading
 
-* run `pongo clean` using the `1.x` version of Pongo
+* Upgrade Pongo
 
-* `cd` into the folder where Pongo resides and do a `git pull`
+  * run `pongo clean` using the `1.x` version of Pongo, to cleanup old artifacts
+    and images
 
-* on your plugin repositories run `pongo init` to update any settings (git-ignoring
-  bash history mostly)
+  * `cd` into the folder where Pongo resides and do a `git pull`, followed by
+    `git checkout 2.0.0`
 
-* If you need Cassandra when testing, then ensure in the plugin repositories that
-  the `.pongo/pongorc` file contains: `--cassandra`, since it is no longer started
-  by default.
+* Upgrade Plugin repositories
 
-### Changes
+  * on your plugin repositories run `pongo init` to update any settings (git-ignoring
+    bash history mostly)
+
+  * If you need Cassandra when testing, then ensure in the plugin repositories that
+    the `.pongo/pongorc` file contains: `--cassandra`, since it is no longer started
+    by default.
+
+  * Update init scripts `.pongo/pongo-setup.sh`. They will now be sourced in `bash`
+    instead of in `sh`.
+
+#### Changes
 
 * the Kong base image is now `Ubuntu` (previously `Alpine`). The default shell
   now is `/bin/bash` (was `/bin/sh`)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ check [this blogpost on the Kong website](https://konghq.com/blog/custom-lua-plu
 Usage: pongo action [options...] [--] [action options...]
 
 Options (can also be added to '.pongo/pongorc'):
-  --no-cassandra     do not start cassandra db
   --no-postgres      do not start postgres db
+  --cassandra        do start cassandra db
   --grpcbin          do start grpcbin (see readme for info)
   --redis            do start redis db (see readme for info)
   --squid            do start squid forward-proxy (see readme for info)
@@ -269,8 +269,8 @@ The available dependencies are:
   - Disable it with `--no-postgres`
   - The Postgres version is controlled by the `POSTGRES` environment variable
 
-* **Cassandra** Kong datastore (started by default)
-  - Disable it with `--no-cassandra`
+* **Cassandra** Kong datastore
+  - Enable it with `--cassandra`
   - The Cassandra version is controlled by the `CASSANDRA` environment variable
 
 * **grpcbin** mock grpc backend
@@ -313,7 +313,7 @@ The available dependencies are:
     ```shell
     # clean environment, start with squid and create a shell
     pongo down
-    pongo up --squid --no-postgres --no-cassandra
+    pongo up --squid --no-postgres
     pongo shell
 
     # connect to httpbin (http), while authenticating
@@ -794,6 +794,33 @@ The result should be a new PR on the Pongo repo.
  * update version in logo at top of this `README`
  * commit as `release x.y.z`, tag as `x.y.z`
  * push commit and tags
+
+
+---
+
+## unreleased 2.x
+
+### Upgrade steps
+
+* run `pongo clean` using the `1.x` version of Pongo
+
+* `cd` into the folder where Pongo resides and do a `git pull`
+
+* on your plugin repositories run `pongo init` to update any settings (git-ignoring
+  bash history mostly)
+
+* If you need Cassandra when testing, then ensure in the plugin repositories that
+  the `.pongo/pongorc` file contains: `--cassandra`, since it is no longer started
+  by default.
+
+### Changes
+
+* the Kong base image is now `Ubuntu` (previously `Alpine`). The default shell
+  now is `/bin/bash` (was `/bin/sh`)
+
+* Support for Kong versions before `2.0` is dropped
+
+* Cassandra is no longer started by default.
 
 ---
 

--- a/assets/default-pongo-setup.sh
+++ b/assets/default-pongo-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # if no file `.pongo/pongo-setup.sh` is found, then this file contains
 # the default setup actions.

--- a/assets/help/init.txt
+++ b/assets/help/init.txt
@@ -14,6 +14,7 @@ The files added (if not there):
    linter through 'pongo lint'.
  - '.editorconfig' containing default editor settings
  - '.luacov' with default settings for the LuaCov test coverage tool
+ - '.pongo/pongorc' default settings for dependecies to start with Pongo
  - '.gitignore'
 
 If the '.gitignore' file already exists it will add the following entries:

--- a/assets/help/pongo.txt
+++ b/assets/help/pongo.txt
@@ -1,8 +1,8 @@
 Usage: pongo <action> [--help] [options...] [--] [action options...]
 
 Options (can also be added to '.pongo/pongorc'):
-  --no-cassandra     do not start cassandra db
   --no-postgres      do not start postgres db
+  --cassandra        do start cassandra db
   --grpcbin          do start grpcbin (see readme for info)
   --redis            do start redis db (see readme for info)
   --squid            do start squid forward-proxy (see readme for info)

--- a/assets/help/run.txt
+++ b/assets/help/run.txt
@@ -5,8 +5,8 @@ not, it will automatically start the environment (and automatically build the
 Kong test images in the process).
 
 Options (see 'pongo up' for details):
-  --no-cassandra     do not start cassandra db
   --no-postgres      do not start postgres db
+  --cassandra        do not start cassandra db
   --grpcbin          do start grpcbin
   etc.
 

--- a/assets/help/up.txt
+++ b/assets/help/up.txt
@@ -4,10 +4,10 @@ Starts the docker-compose environment with required dependency containers for
 testing.
 
 The dependecies can be specified using their name and prefixes by either '--'
-or '--no-'. The only 2 dependencies started by default are 'postgres' and
-'cassandra'. The defaults for a repository can be set by specifying them in the
-'.pongo/pongorc' configuration file (one option per line, including the '--'
-and '--no-' prefixes).
+or '--no-'. The only dependency started by default is 'postgres'. The defaults
+for a repository can be set by specifying them in the '.pongo/pongorc'
+configuration file (one option per line, including the '--' and '--no-'
+prefixes).
 
 Custom (plugin specific) dependencies can be specified by providing a
 docker-compose yaml file in '.pongo'. For an example see:
@@ -18,8 +18,8 @@ repository (custom dependencies must be listed in '.pongo/pongorc' to be shown).
 
 
 Default available dependencies:
-  --no-cassandra     do not start cassandra db
   --no-postgres      do not start postgres db
+  --cassandra        do start cassandra db
   --grpcbin          do start grpcbin (see readme for info)
   --redis            do start redis db (see readme for info)
   --squid            do start squid forward-proxy (see readme for info)
@@ -37,4 +37,4 @@ Custom dependencies may have their own variables.
 
 Example usage:
   pongo up
-  pongo up --no-cassandra --customdependency
+  pongo up --cassandra --no-postgres --customdependency

--- a/assets/kong_export.sh
+++ b/assets/kong_export.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # export the kong configuration to "kong.yml"
 

--- a/assets/kong_migrations_start.sh
+++ b/assets/kong_migrations_start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # will (re)start Kong with a clean database, and an optional imported config
 

--- a/assets/kong_start_dbless.sh
+++ b/assets/kong_start_dbless.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # will (re)start Kong DBless from a config file; kong.y(a)ml/json
 

--- a/assets/parse_git_branch.sh
+++ b/assets/parse_git_branch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # script used to extract git branch name for the Pongo shell command prompt
 

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 
 # USAGE: do not use this file directly. It is the entry script for the
@@ -26,7 +26,7 @@ if [ -z "$KONG_ADMIN_LISTEN" ]; then
 
   # export to override defaults in file, with 0.0.0.0 instead of 127.0.0.1
   export KONG_ADMIN_LISTEN
-  KONG_ADMIN_LISTEN=$(echo "$DEFAULT_ADMIN_LISTEN_SETTING" | sed 's/127\.0\.0\.1/0.0.0.0/g')
+  KONG_ADMIN_LISTEN=${DEFAULT_ADMIN_LISTEN_SETTING//127\.0\.0\.1/0.0.0.0}
 
   unset FILE_WITH_KONG_DEFAULTS
   unset DEFAULT_ADMIN_LISTEN_SETTING

--- a/assets/pongo_profile.sh
+++ b/assets/pongo_profile.sh
@@ -1,11 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 #shebang above is only for ShellCheck linter purposes
 
 # This is the profile script located in /etc/profile.d/pongo_profile.sh
 # It can be used to customise the `pongo shell` behaviour.
-
-alias la='ls -A'
-alias ll='ls -alF'
 
 alias ks='kong restart'
 alias kp='kong stop'
@@ -13,7 +10,7 @@ alias kms='/pongo/kong_migrations_start.sh'
 alias kdbl='/pongo/kong_start_dbless.sh'
 alias kx='/pongo/kong_export.sh'
 
-PS1="\[\e[00m\]\[\033[1;34m\][$PS1_KONG_VERSION:\[\e[91m\]$PS1_REPO_NAME\$(/pongo/parse_git_branch.sh)\[\033[1;34m\]:\[\033[1;92m\]\w\[\033[1;34m\]]$\[\033[00m\] "
+echo 'PS1="\[\e[00m\]\[\033[1;34m\][$PS1_KONG_VERSION:\[\e[91m\]$PS1_REPO_NAME\$(/pongo/parse_git_branch.sh)\[\033[1;34m\]:\[\033[1;92m\]\w\[\033[1;34m\]]$\[\033[00m\] "' >> /root/.bashrc
 
 echo "Welcome to the Pongo shell!"
 echo ""

--- a/assets/set_variables.sh
+++ b/assets/set_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # this requires LOCAL_PATH to be set to the Pongo directory
 

--- a/pongo.sh
+++ b/pongo.sh
@@ -144,7 +144,7 @@ function globals {
   unset ACTION
   FORCE_BUILD=${PONGO_FORCE_BUILD:-false}
   KONG_DEPS_AVAILABLE=( "postgres" "cassandra" "redis" "squid" "grpcbin" "expose")
-  KONG_DEPS_START=( "postgres" "cassandra" )
+  KONG_DEPS_START=( "postgres" )
   KONG_DEPS_CUSTOM=()
   RC_COMMANDS=( "run" "up" "restart" )
   EXTRA_ARGS=()


### PR DESCRIPTION
to make the tests pass we need to update the `kong-plugin` repo as well to no longer test against Cassandra.