### PR TITLE
fix: make EXPAT and LIBXML2 location known to rock when building

### DIFF
--- a/assets/default-pongo-setup.sh
+++ b/assets/default-pongo-setup.sh
@@ -14,6 +14,6 @@ for rockspec in $(find /kong-plugin -maxdepth 1 -type f -name '*.rockspec'); do
     luarocks remove --force "$rockname"
   fi
   # install any required dependencies
-  luarocks install --only-deps "$rockspec"
+  luarocks install --only-deps "$rockspec" EXPAT_DIR=/usr/local/kong LIBXML2_DIR=/usr/local/kong
 done
 


### PR DESCRIPTION
As expat and libxml2 are installed in non-standard locations, they need to be passed to luarock when building.  We're not currently including a lot of libraries, so this approach, albeit a little ugly, should do.