### PR TITLE
fix(db-import) for enterprise in 'kms' shell alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,8 @@ The result should be a new PR on the Pongo repo.
 
 * Feat: add the Pongo version that build the image to the image, and check it
   against the used version to inform user of mismatches.
+* Fix: import declarative config in Enterprise versions (officially not supported)
+  in the 'kms' shell alias.
 
 ---
 

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -20,6 +20,7 @@ COPY assets/kong_start_dbless.sh     /pongo/kong_start_dbless.sh
 COPY assets/kong_export.sh           /pongo/kong_export.sh
 COPY assets/parse_git_branch.sh      /pongo/parse_git_branch.sh
 COPY assets/pongo_logo.sh            /pongo/pongo_logo.sh
+COPY assets/workspace_update.lua     /pongo/workspace_update.lua
 COPY assets/pongo_profile.sh         /etc/profile.d/pongo_profile.sh
 
 USER root

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -33,8 +33,11 @@ if [ -z "$KONG_ADMIN_LISTEN" ]; then
 fi
 
 
-# add the plugin code to the LUA_PATH such that the plugin will be found
-export "LUA_PATH=/kong-plugin/?.lua;/kong-plugin/?/init.lua;;"
+# add the plugin code to the LUA_PATH such that the plugin will be found, and add the default resty libs
+RESTY_LUALIB=$(dirname "$(dirname "$(command -v resty)")")/lualib
+export "LUA_PATH=/kong-plugin/?.lua;/kong-plugin/?/init.lua;$RESTY_LUALIB/?.lua;$RESTY_LUALIB/?/init.lua;;"
+export "LUA_CPATH=$RESTY_LUALIB/?.so;;"
+unset RESTY_LUALIB
 
 # many of the test config files for Kong will have a nameserver set to 8.8.8.8
 # this will clearly not work with Docker, so we need to override it. Hence we

--- a/assets/workspace_update.lua
+++ b/assets/workspace_update.lua
@@ -1,0 +1,47 @@
+-- Workaround for the import of a declarative file in Kong Enterprise.
+-- Officially it is not supported.
+--
+-- The import fails because there already is a "default" workspace, even in an
+-- empty database. So the imported "default" workspace collides.
+--
+-- This file serves 2 purposes:
+-- 1. Returns the ID of the default namespace (in the decl. file), on stdout
+-- 2. if the first argument (new default namespace id) is given then
+-- returns the entire input, where the default WS id will be replaced by
+-- the given one, so the reult becomes "importable"
+
+local lyaml = require("lyaml")
+local json = require("cjson.safe")
+local rawdata = assert(io.stdin:read("*a"))
+local kong_uuid = arg[1]
+local file_uuid
+
+-- parse file
+local data = json.decode(rawdata)
+if not data then
+  data = assert(lyaml.load(rawdata), "failed parsing as JSON or Yaml")
+end
+
+-- get default WS UUID from file
+for _, workspace in ipairs(data.workspaces or {}) do
+    if workspace.name == "default" then
+        file_uuid = workspace.id
+        break
+    end
+end
+
+if kong_uuid == nil then
+    -- no ID argument provided, so we return the one in the input
+    if file_uuid then
+        io.stdout:write(file_uuid)
+        os.exit(0)
+    end
+    -- not found, return nothing
+    os.exit(1)
+end
+
+
+kong_uuid = kong_uuid:gsub('"', '') -- remove all double quotes from the uuid
+file_uuid = file_uuid:gsub('-', '%%-') -- escape dashes in uuid
+local updated_data = rawdata:gsub(file_uuid, kong_uuid)
+io.stdout:write(updated_data)


### PR DESCRIPTION
previously would fail with a "unique violation" becasue the default worksapce already existed with a different uuid.