### PR TITLE
style(redis) change default redis cluster name from `rc` to `redis-cl…

### DIFF
--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -73,7 +73,7 @@ export KONG_SPEC_REDIS_HOST=redis
 # Kong test-helpers 3.0.0+
 export KONG_SPEC_TEST_REDIS_HOST=redis
 # Support Redis Cluster (RC)
-export KONG_SPEC_TEST_REDIS_CLUSTER_ADDRESSES="rc:7000,rc:7001,rc:7003"
+export KONG_SPEC_TEST_REDIS_CLUSTER_ADDRESSES="redis-clusters:7000,redis-clusters:7001,redis-clusters:7003"
 
 # set the certificate store
 export KONG_LUA_SSL_TRUSTED_CERTIFICATE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
style(redis) change default redis cluster name from `rc` to `redis-clusters`

`rc` is ambiguous and change to `redis-clusters` in accord with https://github.com/Kong/kong-ee/pull/3603#discussion_r993053879