### PR TITLE
feat(*): allow using a development build image

### DIFF
--- a/assets/set_variables.sh
+++ b/assets/set_variables.sh
@@ -73,8 +73,23 @@ function create_all_versions_array {
 create_all_versions_array
 
 
+function get_version_from_file_system {
+  local dir=$1
+  KONG_SOURCE_LOCATION=$dir $dir/distribution/grep-kong-version.sh
+}
+
 function is_enterprise {
   local check_version=$1
+  if [ -d $check_version ]
+  then
+    local kong_version=$(get_version_from_file_system $check_version)
+    if [[ $kong_version =~ [0-9]\.[0-9]\.[0-9]\.[0-9] ]]
+    then
+      return 1
+    else
+      return 0
+    fi
+  fi
   local VERSION
   for VERSION in ${KONG_EE_VERSIONS[*]} $DEVELOPMENT_EE $STABLE_EE; do
     if [[ "$VERSION" == "$check_version" ]]; then
@@ -93,6 +108,16 @@ function is_commit_based {
       return 0
     fi
   done;
+  return 1
+}
+
+# this is to detect file system builds
+function is_file_system_based {
+  local check_version=$1
+  if [ -d $check_version ]
+  then
+    return 0
+  fi
   return 1
 }
 

--- a/assets/set_variables.sh
+++ b/assets/set_variables.sh
@@ -75,14 +75,15 @@ create_all_versions_array
 
 function get_version_from_file_system {
   local dir=$1
-  KONG_SOURCE_LOCATION=$dir $dir/distribution/grep-kong-version.sh
+  KONG_SOURCE_LOCATION="$dir" "$dir"/distribution/grep-kong-version.sh
 }
 
 function is_enterprise {
   local check_version=$1
-  if [ -d $check_version ]
+  if [ -d "$check_version" ]
   then
-    local kong_version=$(get_version_from_file_system $check_version)
+    local kong_version
+    kong_version=$(get_version_from_file_system "$check_version")
     if [[ $kong_version =~ [0-9]\.[0-9]\.[0-9]\.[0-9] ]]
     then
       return 1

--- a/assets/set_variables.sh
+++ b/assets/set_variables.sh
@@ -113,12 +113,7 @@ function is_commit_based {
 
 # this is to detect file system builds
 function is_file_system_based {
-  local check_version=$1
-  if [ -d $check_version ]
-  then
-    return 0
-  fi
-  return 1
+  [[ -d $1 ]]
 }
 
 function version_exists {

--- a/assets/update_versions.sh
+++ b/assets/update_versions.sh
@@ -73,6 +73,42 @@ function clean_artifacts {
 }
 
 
+function copy_artifacts {
+    local DIR=$1
+    mkdir "$DIR/kong"
+    cp Makefile  "$DIR/kong/"
+    cp -R bin    "$DIR/kong/"
+
+    mkdir "$DIR/kong/spec"
+    for fname in spec/*; do
+        case $fname in
+            (spec/[0-9]*)
+            # These we skip
+            ;;
+            (*)
+                # everything else we copy
+                cp -R "$fname" "$DIR/kong/spec/"
+                ;;
+        esac
+    done
+
+    if [[ -d spec-ee ]]; then
+        mkdir "$DIR/kong/spec-ee"
+        for fname in spec-ee/*; do
+            case $fname in
+                (spec-ee/[0-9]*)
+                # These we skip
+                ;;
+                (*)
+                    # everything else we copy
+                    cp -R "$fname" "$DIR/kong/spec-ee/"
+                    ;;
+            esac
+        done
+    fi
+}
+
+
 function update_single_version_artifacts {
     # MUST be in the proper git repo before calling!
     # pass in a version tag, and optionally a commit id.
@@ -91,37 +127,7 @@ function update_single_version_artifacts {
         warn "cannot checkout version $VERSION. Is the tag missing? skipping it for now..."
     else
         mkdir "../kong-versions/$VERSION"
-        mkdir "../kong-versions/$VERSION/kong"
-        cp Makefile  "../kong-versions/$VERSION/kong/"
-        cp -R bin    "../kong-versions/$VERSION/kong/"
-
-        mkdir "../kong-versions/$VERSION/kong/spec"
-        for fname in spec/*; do
-            case $fname in
-            (spec/[0-9]*)
-                # These we skip
-                ;;
-            (*)
-                # everything else we copy
-                cp -R "$fname" "../kong-versions/$VERSION/kong/spec/"
-                ;;
-            esac
-        done
-
-        if [[ -d spec-ee ]]; then
-            mkdir "../kong-versions/$VERSION/kong/spec-ee"
-            for fname in spec-ee/*; do
-                case $fname in
-                (spec-ee/[0-9]*)
-                    # These we skip
-                    ;;
-                (*)
-                    # everything else we copy
-                    cp -R "$fname" "../kong-versions/$VERSION/kong/spec-ee/"
-                    ;;
-                esac
-            done
-        fi
+        copy_artifacts "../kong-versions/$VERSION"
     fi
 }
 

--- a/pongo.sh
+++ b/pongo.sh
@@ -717,11 +717,12 @@ function build_image {
 
   if is_file_system_based "$KONG_VERSION"; then
     ARTIFACT_DIR="$(mktemp -d pongo.XXXXX)"
+    # shellcheck disable=SC1090  # do not follow source
     source "${LOCAL_PATH}/assets/update_versions.sh"
-    pushd > /dev/null "$KONG_VERSION"
+    pushd > /dev/null "$KONG_VERSION" || exit 1
     copy_artifacts "${LOCAL_PATH}/${ARTIFACT_DIR}"
     KONG_DEV_FILES="$ARTIFACT_DIR/kong"
-    popd > /dev/null
+    popd > /dev/null || exit 1
   else
     KONG_DEV_FILES="./kong-versions/$VERSION/kong"
   fi

--- a/pongo.sh
+++ b/pongo.sh
@@ -716,10 +716,11 @@ function build_image {
   fi
 
   if is_file_system_based "$KONG_VERSION"; then
-    KONG_DEV_FILES=$(mktemp -d pongo.XXXXX)
+    local artifact_dir=$(mktemp -d pongo.XXXXX)
     source "${LOCAL_PATH}/assets/update_versions.sh"
     pushd "$KONG_VERSION"
-    copy_artifacts "${LOCAL_PATH}/${KONG_DEV_FILES}"
+    copy_artifacts "${LOCAL_PATH}/${artifact_dir}"
+    KONG_DEV_FILES=$artifact_dir/kong
     popd
   else
     KONG_DEV_FILES="./kong-versions/$VERSION/kong"

--- a/pongo.sh
+++ b/pongo.sh
@@ -716,12 +716,12 @@ function build_image {
   fi
 
   if is_file_system_based "$KONG_VERSION"; then
-    local artifact_dir=$(mktemp -d pongo.XXXXX)
+    ARTIFACT_DIR="$(mktemp -d pongo.XXXXX)"
     source "${LOCAL_PATH}/assets/update_versions.sh"
-    pushd "$KONG_VERSION"
-    copy_artifacts "${LOCAL_PATH}/${artifact_dir}"
-    KONG_DEV_FILES=$artifact_dir/kong
-    popd
+    pushd > /dev/null "$KONG_VERSION"
+    copy_artifacts "${LOCAL_PATH}/${ARTIFACT_DIR}"
+    KONG_DEV_FILES="$ARTIFACT_DIR/kong"
+    popd > /dev/null
   else
     KONG_DEV_FILES="./kong-versions/$VERSION/kong"
   fi
@@ -747,7 +747,7 @@ function build_image {
     "$LOCAL_PATH" || err "Error: failed to build test environment"
 
   if is_file_system_based "$KONG_VERSION"; then
-    rm -rf $(KONG_DEV_FILES)
+    rm -rf "$ARTIFACT_DIR"
   fi
   msg "image '$KONG_TEST_IMAGE' successfully built"
 }


### PR DESCRIPTION
To support testing plugins with an image built during CI runs, pongo needs to be able to use artifacts from an arbitrary local directory.  This change makes pongo accept a local path in `KONG_VERSION` which is then used to determine the version number and to copy the artifact files which would normally be taken from the `kong-versions/` directory.

The idea is to build a temporary docker image in CI using:

`make package-kong build-test-container KONG_SOURCE_LOCATION=$HOME/kong-ee`

and then run pongo to test plugins like this:

`KONG_IMAGE=kong/kong:amd64-3.1.0.0-ubuntu KONG_VERSION=$HOME/kong-ee pongo run`