### PR TITLE
feat: allow building pongo image from specially tagged test image

### DIFF
--- a/assets/set_variables.sh
+++ b/assets/set_variables.sh
@@ -86,25 +86,22 @@ function is_enterprise {
 
 # this is to detect "commit-based" versions; the development ones
 function is_commit_based {
-  local check_version=$1
-  local VERSION
-  for VERSION in $DEVELOPMENT_CE $DEVELOPMENT_EE; do
-    if [[ "$VERSION" == "$check_version" ]]; then
-      return 0
-    fi
-  done;
-  return 1
+  [[ $1 =~ ($DEVELOPMENT_CE|$DEVELOPMENT_EE|[0-9a-f]+) ]]
 }
 
 function version_exists {
   local version=$1
-  local entry
-  # not testing for "stable" tags here, since the resolve stage changes them to actual versions
-  for entry in ${KONG_VERSIONS[*]} $DEVELOPMENT_CE $DEVELOPMENT_EE; do
-    if [[ "$version" == "$entry" ]]; then
-      return 0
-    fi
-  done;
+  if is_commit_based $version; then
+    return 0
+  else
+    local entry
+    # not testing for "stable" tags here, since the resolve stage changes them to actual versions
+    for entry in ${KONG_VERSIONS[*]}; do
+      if [[ "$version" == "$entry" ]]; then
+        return 0
+      fi
+    done
+  fi
   return 1
 }
 

--- a/assets/set_variables.sh
+++ b/assets/set_variables.sh
@@ -91,7 +91,7 @@ function is_commit_based {
 
 function version_exists {
   local version=$1
-  if is_commit_based $version; then
+  if is_commit_based "$version"; then
     return 0
   else
     local entry

--- a/assets/set_variables.sh
+++ b/assets/set_variables.sh
@@ -86,7 +86,7 @@ function is_enterprise {
 
 # this is to detect "commit-based" versions; the development ones
 function is_commit_based {
-  [[ $1 =~ ($DEVELOPMENT_CE|$DEVELOPMENT_EE|[0-9a-f]+) ]]
+  [[ $1 =~ ^($DEVELOPMENT_CE|$DEVELOPMENT_EE|[0-9a-f]+)$ ]]
 }
 
 function version_exists {

--- a/assets/update_versions.sh
+++ b/assets/update_versions.sh
@@ -172,11 +172,13 @@ function update_artifacts {
 function update_development {
     # $1 must be the requested version: the "DEV" special cases
     # $2 must be the commit id
+    # $3 must be 1 for Kong Enterprise
     VERSION=$1
     COMMIT=$2
+    IS_ENTERPRISE=$3
 
     local repo
-    if is_enterprise "$VERSION"; then
+    if [[ $IS_ENTERPRISE == 1 ]]; then
       repo=kong-ee
     else
       repo=kong

--- a/pongo.sh
+++ b/pongo.sh
@@ -557,7 +557,7 @@ function get_version {
 
   IS_ENTERPRISE=0
 
-  if [[ $KONG_IMAGE =~ kong/kong:test(-ee)?-([0-9a-f]+) ]]; then
+  if [[ $KONG_IMAGE =~ ^kong/kong:test(-ee)?-([0-9a-f]+)$ ]]; then
     if [[ ${BASH_REMATCH[1]} == -ee ]]; then
       IS_ENTERPRISE=1
     fi

--- a/pongo.sh
+++ b/pongo.sh
@@ -558,10 +558,7 @@ function get_version {
   IS_ENTERPRISE=0
 
   if [[ $KONG_IMAGE =~ kong/kong:test(-ee)?-([0-9a-f]+) ]]; then
-    if [[ -z ${BASH_REMATCH[1]} ]]; then
-      KONG_REPO=git@github.com:Kong/kong
-    else
-      KONG_REPO=git@github.com:Kong/kong-ee
+    if [[ ${BASH_REMATCH[1]} == -ee ]]; then
       IS_ENTERPRISE=1
     fi
     KONG_VERSION=${BASH_REMATCH[2]}


### PR DESCRIPTION
This change adds the possibility to specify a temporary test image as KONG_IMAGE, similar to using the 'dev' and 'dev-ee' pseudo versions. The image name contains the git tag from which it was built.  The added logic will determine KONG_VERSION and whether we're dealing with CE or EE from the image name