### PR TITLE
test(redis-cluster) change redis cluster service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,13 @@ The result should be a new PR on the Pongo repo.
 
 ---
 
+## unreleased
+
+* Style: change redis cluster service name from `rc` to `redis-clusters`.
+  Refer to <https://github.com/Kong/kong-pongo/pull/355>.
+
+---
+
 ## 1.3.0 released 19-Sep-2022
 
 * Feat: Kong Enterprise 3.0.0.0

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -70,7 +70,7 @@ export KONG_SPEC_REDIS_HOST=redis
 # Kong test-helpers 3.0.0+
 export KONG_SPEC_TEST_REDIS_HOST=redis
 # Support Redis Cluster (RC)
-export KONG_SPEC_TEST_REDIS_CLUSTER_ADDRESSES="rc:7000,rc:7001,rc:7003"
+export KONG_SPEC_TEST_REDIS_CLUSTER_ADDRESSES="redis-clusters:7000,redis-clusters:7001,redis-clusters:7003"
 
 # set the certificate store
 export KONG_LUA_SSL_TRUSTED_CERTIFICATE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
The redis cluster service name from `rc` to `redis-clusters` PR #344 merged released in `2.1.0`.

For compatibility with `1.3.0`, this PR is created.