### PR TITLE
fix(realpath) Apple's realpath doesn't support `--version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,9 @@ The result should be a new PR on the Pongo repo.
 
 ## 2.x.0 unreleased
 
+* Fix: Apple recently started shipping `realpath` in their OS. But it doesn't support the
+  `--version` flag, so it was not detected as installed.
+
 * Feat: Kong Enterprise 3.1.1.3
 
 * Feat: Kong Enterprise 3.1.1.2

--- a/pongo.sh
+++ b/pongo.sh
@@ -181,7 +181,7 @@ function check_tools {
     COMPOSE_COMMAND="docker-compose"
   fi
 
-  realpath --version > /dev/null 2>&1
+  realpath . > /dev/null 2>&1
   if [[ ! $? -eq 0 ]]; then
     >&2 echo "'realpath' command not found, please install it, and make it available in the path (on Mac use Brew to install the 'coreutils' package)."
     missing=true


### PR DESCRIPTION
Apple recently (probably Ventura) started shipping `realpath` in their OS. But it doesn't support the `--version` flag, hence detection failed.