### PR TITLE
fix(image): install psmisc and net-tools to provide `fuser` and `netstat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,7 +811,13 @@ The result should be a new PR on the Pongo repo.
 
 ---
 
-## 2.5.0 unreleased
+## 2.5.x unreleased
+
+* Fix: Add missing `fuser` and `netstat` utility that is required for certain test functions.
+
+---
+
+## 2.5.0 released 7-Feb-2023
 
 * Fix: Apple recently started shipping `realpath` in their OS. But it doesn't support the
   `--version` flag, so it was not detected as installed
@@ -820,8 +826,6 @@ The result should be a new PR on the Pongo repo.
 * Feat: Kong Enterprise 3.1.1.3
 
 * Feat: Kong Enterprise 3.1.1.2
-
-* Fix: Add missing `fuser` and `netstat` utility that is required for certain test functions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -821,6 +821,8 @@ The result should be a new PR on the Pongo repo.
 
 * Feat: Kong Enterprise 3.1.1.2
 
+* Fix: Add missing `fuser` and `netstat` utility that is required for certain test functions.
+
 ---
 
 ## 2.4.0 released 20-Jan-2023

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -37,8 +37,11 @@ USER root
 # But that means hardcoding and that doesn't play well with the nature of Pongo
 # that should be independent of Kong versions.
 
+# psmisc: provides `fuser`
+# net-tools: provides `netstat`
+
 RUN apt update \
-    && apt install -y zip make jq m4 curl build-essential wget git libssl-dev zlib1g-dev lsb-release
+    && apt install -y zip make jq m4 curl build-essential wget git libssl-dev zlib1g-dev lsb-release psmisc net-tools
 RUN /pongo/install-python.sh
 RUN pip3 install httpie
 RUN curl -k -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin


### PR DESCRIPTION
`fuser` as added as a depenndecy in 3.0.0.0 to test opentelemetry plugin,
but as that's a CE plugin, it wasn't using pongo to test before. In 3.2.x.x, a
new EE plugin starts to use the same helper function that calls `fuser`
(and also `netstat`) and result in a `command not found` in pongo test.