### PR TITLE
fix(realpath) Apple's realpath doesn't support `--version`(#380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,10 @@ The result should be a new PR on the Pongo repo.
 * Fix: Apple recently started shipping `realpath` in their OS. But it doesn't support the
   `--version` flag, so it was not detected as installed.
 
+* Fix: if the license cannot be downloaded the license variable would contain the
+  404 html response, which would cause unrelated problems. The variable is now
+  cleared upon failure.
+
 ---
 
 ## 1.3.0 released 19-Sep-2022

--- a/pongo.sh
+++ b/pongo.sh
@@ -547,6 +547,7 @@ function get_license {
         # yet more additional dependenies like jq or similar.
         warn "failed to download the Kong Enterprise license file!
           $KONG_LICENSE_DATA"
+        unset KONG_LICENSE_DATA
       fi
     fi
   fi


### PR DESCRIPTION
Apple recently (probably Ventura) started shipping `realpath` in their
OS. But it doesn't support the `--version` flag, hence detection
failed.