### PR TITLE
fix(down): remove volumes automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,14 @@ The result should be a new PR on the Pongo repo.
 
 ---
 
+## unreleased
+
+* Fix: `pongo down` would not remove volumes. This
+  caused orphaned volumes on long running VMs as well as on personal
+  machines.
+
+---
+
 ## 2.7.0 released 7-Jul-2023
 
 * Feat: Kong Enterprise 2.8.4.2, which means that Pongo 2.x will support the

--- a/pongo.sh
+++ b/pongo.sh
@@ -788,7 +788,7 @@ function pongo_down {
   # if '--all' is passed then kill all environments, otherwise just current
   if [[ ! "$1" == "--all" ]]; then
     # just current env
-    compose down --remove-orphans
+    compose down --remove-orphans --volumes
     exit
   fi
 
@@ -801,7 +801,7 @@ function pongo_down {
     PROJECT_ID=${network: -8}
     PROJECT_NAME=${PROJECT_NAME_PREFIX}${PROJECT_ID}
     SERVICE_NETWORK_NAME=${SERVICE_NETWORK_PREFIX}${PROJECT_ID}
-    compose down --remove-orphans
+    compose down --remove-orphans --volumes
   done < <(docker network ls --filter 'name='$SERVICE_NETWORK_PREFIX --format '{{.Name}}')
 
   PROJECT_ID=$p_id
@@ -1081,7 +1081,7 @@ function main {
     ;;
 
   restart)
-    compose down --remove-orphans
+    compose down --remove-orphans --volumes
     compose_up
     ;;
 


### PR DESCRIPTION
'docker compose down' will not by default remove volumes. This caused orphaned volumes on long running VMs as well as on personal machines. By adding the `--volumes` flag it now will remove them.