### PR TITLE
fix(shell): change prefix for health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,13 @@ The result should be a new PR on the Pongo repo.
 
 ---
 
+## unreleased
+
+* Fix: health-checks on Pongo container. Use proper prefix.
+  [#456](https://github.com/Kong/kong-pongo/pull/456).
+
+---
+
 ## 2.9.0 released 08-Nov-2023
 
 * Feat: Kong Enterprise 3.5.0.0

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -152,6 +152,16 @@ services:
       - PONGO_COMMAND=${ACTION}
       - PONGO_NETWORK=${SERVICE_NETWORK_NAME}
       - PONGO_ID=${PROJECT_ID}
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test:
+      - CMD
+      - kong
+      - health
+      - --prefix=/kong-plugin/servroot/
+      timeout: 10s
+      disable: ${SERVICE_DISABLE_HEALTHCHECK:-false}
     networks:
       pongo-test-network:
         aliases:


### PR DESCRIPTION
Since Pongo sets the prefix to use to `/kong-plugin/servroot/` the healthchecks would always fail because they would check in the default location. This fixes them.

Health is ok, if Kong is running in the container. So in case of a `pongo shell` it is unhealthy until Kong is started.