### PR TITLE
feat: support access to host runner's services

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,8 @@ The result should be a new PR on the Pongo repo.
 
 * Fix: health-checks on Pongo container. Use proper prefix.
   [#456](https://github.com/Kong/kong-pongo/pull/456).
+* Feat: support access to host runner's services.
+  [#473](https://github.com/Kong/kong-pongo/pull/473).
 
 ---
 

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -162,6 +162,8 @@ services:
       - --prefix=/kong-plugin/servroot/
       timeout: 10s
       disable: ${SERVICE_DISABLE_HEALTHCHECK:-false}
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
     networks:
       pongo-test-network:
         aliases:


### PR DESCRIPTION
By default, workflows run on a Linux OS. For containers to access to host services, we should update the docker compose file to include `host.docker.internal`.

This would significantly reduce the number of containers and resources required for EE plugins tests.

Refs: https://stackoverflow.com/a/62431165/2336707