### PR TITLE
fix(*) only mount logs directory and use a different prefix

### DIFF
--- a/assets/docker-compose-linux-extend.yml
+++ b/assets/docker-compose-linux-extend.yml
@@ -1,0 +1,6 @@
+version: '3.5'
+
+services:
+  kong:
+    volumes:
+      - ${PONGO_WD}/servroot:/kong-prefix

--- a/assets/docker-compose-nonlinux-extend.yml
+++ b/assets/docker-compose-nonlinux-extend.yml
@@ -1,0 +1,6 @@
+version: '3.5'
+
+services:
+  kong:
+    volumes:
+      - ${PONGO_WD}/servroot/logs:/kong-prefix/logs

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -170,4 +170,3 @@ services:
           - ${SERVICE_NETWORK_NAME}-kong.${SERVICE_NETWORK_NAME}
     volumes:
       - ${PONGO_WD}:/kong-plugin
-      - ${PONGO_WD}/servroot/logs:/kong-prefix/logs

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -170,3 +170,4 @@ services:
           - ${SERVICE_NETWORK_NAME}-kong.${SERVICE_NETWORK_NAME}
     volumes:
       - ${PONGO_WD}:/kong-plugin
+      - ${PONGO_WD}/servroot/logs:/kong-prefix/logs

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -62,8 +62,7 @@ if [ -z "$KONG_DNS_RESOLVER" ]; then
   fi
 fi
 
-# set working dir in mounted volume to be able to check the logs
-export KONG_PREFIX=/kong-plugin/servroot
+export KONG_PREFIX=/kong-prefix
 
 # set debug logs; specifically for the 'shell' command, tests already have it
 export KONG_LOG_LEVEL=debug
@@ -106,14 +105,14 @@ fi
 
 # Modify the 'kong' user to match the ownership of the mounted plugin folder
 # Kong will not start because of permission errors if it cannot write to the
-# /kong-plugin/servroot folder (which resides on the mount).
+# /kong-prefix folder (which created by volume mount /kong-prefix/logs by root).
 # Since those permissions are controlled by the host, we update the 'kong' user
 # inside the container to match the UID and GID.
-if [ -d /kong-plugin ]; then
+if [ -d /kong-prefix ]; then
   KONG_UID=$(id -u kong)
   KONG_GID=$(id -g kong)
-  MOUNT_UID=$(stat -c "%u" /kong-plugin)
-  MOUNT_GID=$(stat -c "%g" /kong-plugin)
+  MOUNT_UID=$(stat -c "%u" /kong-prefix)
+  MOUNT_GID=$(stat -c "%g" /kong-prefix)
   if [ ! "$KONG_GID" = "$MOUNT_GID" ]; then
     # change KONG_GID to the ID of the folder owner group
     groupmod -g "$MOUNT_GID" --non-unique kong

--- a/pongo.sh
+++ b/pongo.sh
@@ -27,10 +27,6 @@ function globals {
   DOCKER_COMPOSE_FILES="-f ${LOCAL_PATH}/assets/docker-compose.yml"
   # macOS or WSL working on a drvfs mount doesn't support named pipes or Unix Domain Socket
   if [ "$(uname -s)" == "Darwin" ] || ! (rm -f .pongo_test.sock; mkfifo .pongo_test.sock) 2>/dev/null; then
-    warn "Current directory doesn't support nix Domain Socket, thus only logs are"
-    warn "exposed onto host. To view other files under servroot, exec into the"
-    warn "pongo container and inspect \$KONG_PREFIX directory"
-
     rm -f .pongo_test.sock
     DOCKER_COMPOSE_FILES="$DOCKER_COMPOSE_FILES -f ${LOCAL_PATH}/assets/docker-compose-nonlinux-extend.yml"
   else


### PR DESCRIPTION
Pongo mounts `/kong-plugin` to current folder and use `/kong-plugin/servroot` as default prefix
so that developer can easily access logs. On macOS, such directory is implemented as VM file shared
and doesn't support binding a unix domain socket; on windows, if current directory from the 9p fs shared
from Windows volumes, binding unix domain socket is also not supported.

This fix makes only `$KONG_PREFIX/logs` a mount from host on such platform, thus makes Kong able to start.
This is considered a short term fix until Kong implemented to move UDS sockets to a subdirectory. By then,
the whole $KONG_PREFIX can be mounted again, while the sockets subdirectory will become a symlink.

KAG-5588
KAG-3284