### PR TITLE
fix(versions): resolve EE-versions by the last 2 digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 * Fix: health-checks on Pongo container. Use proper prefix.
   [#456](https://github.com/Kong/kong-pongo/pull/456).
 
+* Fix: version resolving, EE versions have 2 patch versions, now Pongo will resolve
+  them both. So 3.4.1.x now resolves to latest within 3.4, being 3.4.2.0.
+  [#477](https://github.com/Kong/kong-pongo/pull/477).
+
 * Feat: support access to host runner's services.
   [#473](https://github.com/Kong/kong-pongo/pull/473).
 

--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ jobs:
         - "2.8.x"
         - "3.5.x"
         - "dev"
-        - "3.5.0.x"
+        - "3.5.x.x"
         #- "dev-ee"    # Kong internal only, requires access to source code
 
     steps:

--- a/assets/ci/pongo_run.helper.sh
+++ b/assets/ci/pongo_run.helper.sh
@@ -50,8 +50,17 @@ function versions_to_test {
 
     # step 1) add wilcard to get unique versions by major-minor (ignoring patch)
     if [[ "$VERSION" =~ ^[0-9] ]]; then
-      # numeric version, so not a DEV one; replace last digit with 'x' wildcard
-      VERSION="${VERSION:0:${#VERSION}-1}x"
+      # numeric version, so not a DEV one; replace last digits with 'x' wildcard
+      local segments
+      segments=$(( $(echo "$VERSION" | tr -cd '.' | wc -c) + 1 ))
+      if ((segments == 4)); then
+        # this is a 4 segment version, which means it is an EE version.
+        # For an EE version we need to replace the last 2 digits
+        VERSION="${VERSION:0:${#VERSION}-3}x.x"
+      else
+        # this should then be an OSS version, replace 1 digit
+        VERSION="${VERSION:0:${#VERSION}-1}x"
+      fi
     fi
 
     # step 2) store version if not already in our CLEAN_VERSIONS array

--- a/assets/set_variables.sh
+++ b/assets/set_variables.sh
@@ -128,12 +128,28 @@ function resolve_version {
     # resolve trailing "x" to proper version
     local new_version=$KONG_VERSION
     local entry
-    for entry in ${KONG_VERSIONS[*]}; do
-      if [[ "${KONG_VERSION:0:${#KONG_VERSION}-1}" == "${entry:0:${#entry}-1}" ]]; then
-        # keep replacing, last one wins
-        new_version=$entry
-      fi
-    done;
+
+    local segments
+    segments=$(( $(echo "$KONG_VERSION" | tr -cd '.' | wc -c) + 1 ))
+
+    if ((segments == 4)); then
+      # this is a 4 segment version, which means it is an EE version.
+      # For an EE version we need to resolve the last 2 segments
+      for entry in ${KONG_VERSIONS[*]}; do
+        if [[ "${KONG_VERSION:0:${#KONG_VERSION}-3}" == "${entry:0:${#entry}-3}" ]]; then
+          # keep replacing, last one wins
+          new_version=$entry
+        fi
+      done;
+    else
+      # this should then be an OSS version
+      for entry in ${KONG_VERSIONS[*]}; do
+        if [[ "${KONG_VERSION:0:${#KONG_VERSION}-1}" == "${entry:0:${#entry}-1}" ]]; then
+          # keep replacing, last one wins
+          new_version=$entry
+        fi
+      done;
+    fi
     if [[ "$new_version" == "$KONG_VERSION" ]]; then
       warn "Could not resolve Kong version: '$KONG_VERSION'"
     else


### PR DESCRIPTION
Enterprise versions have patch versions both on 3rd and 4th digit whilst resolving only took 4th into account. Eg. 3.4.1.x resolved to 3.4.1.1, whilst 3.4.2.0 is actually the latest within the 3.4 range.