### PR TITLE
Revert "fix(*) only mount logs directory and use a different prefix"

### DIFF
--- a/assets/docker-compose-linux-extend.yml
+++ b/assets/docker-compose-linux-extend.yml
@@ -1,6 +1,0 @@
-version: '3.5'
-
-services:
-  kong:
-    volumes:
-      - ${PONGO_WD}/servroot:/kong-prefix

--- a/assets/docker-compose-nonlinux-extend.yml
+++ b/assets/docker-compose-nonlinux-extend.yml
@@ -1,6 +1,0 @@
-version: '3.5'
-
-services:
-  kong:
-    volumes:
-      - ${PONGO_WD}/servroot/logs:/kong-prefix/logs

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -62,7 +62,8 @@ if [ -z "$KONG_DNS_RESOLVER" ]; then
   fi
 fi
 
-export KONG_PREFIX=/kong-prefix
+# set working dir in mounted volume to be able to check the logs
+export KONG_PREFIX=/kong-plugin/servroot
 
 # set debug logs; specifically for the 'shell' command, tests already have it
 export KONG_LOG_LEVEL=debug
@@ -105,14 +106,14 @@ fi
 
 # Modify the 'kong' user to match the ownership of the mounted plugin folder
 # Kong will not start because of permission errors if it cannot write to the
-# /kong-prefix folder (which created by volume mount /kong-prefix/logs by root).
+# /kong-plugin/servroot folder (which resides on the mount).
 # Since those permissions are controlled by the host, we update the 'kong' user
 # inside the container to match the UID and GID.
-if [ -d /kong-prefix ]; then
+if [ -d /kong-plugin ]; then
   KONG_UID=$(id -u kong)
   KONG_GID=$(id -g kong)
-  MOUNT_UID=$(stat -c "%u" /kong-prefix)
-  MOUNT_GID=$(stat -c "%g" /kong-prefix)
+  MOUNT_UID=$(stat -c "%u" /kong-plugin)
+  MOUNT_GID=$(stat -c "%g" /kong-plugin)
   if [ ! "$KONG_GID" = "$MOUNT_GID" ]; then
     # change KONG_GID to the ID of the folder owner group
     groupmod -g "$MOUNT_GID" --non-unique kong

--- a/pongo.sh
+++ b/pongo.sh
@@ -25,14 +25,6 @@ function globals {
 
   DOCKER_FILE=${PONGO_DOCKER_FILE:-$LOCAL_PATH/assets/Dockerfile}
   DOCKER_COMPOSE_FILES="-f ${LOCAL_PATH}/assets/docker-compose.yml"
-  # macOS or WSL working on a drvfs mount doesn't support named pipes or Unix Domain Socket
-  if [ "$(uname -s)" == "Darwin" ] || ! (rm -f .pongo_test.sock; mkfifo .pongo_test.sock) 2>/dev/null; then
-    rm -f .pongo_test.sock
-    DOCKER_COMPOSE_FILES="$DOCKER_COMPOSE_FILES -f ${LOCAL_PATH}/assets/docker-compose-nonlinux-extend.yml"
-  else
-    DOCKER_COMPOSE_FILES="$DOCKER_COMPOSE_FILES -f ${LOCAL_PATH}/assets/docker-compose-linux-extend.yml"
-  fi
-
   IMAGE_BASE_NAME=kong-pongo-test
 
   # the path where the plugin source is located, as seen from Pongo (this script)


### PR DESCRIPTION
Reverts Kong/kong-pongo#474

Due to report of it breaks on existing versions starting from 3.2.x.x, we will keep this change in a sepreate branch only
and revert it from master.