### PR TITLE
feat(shell): enable auto-reload in interactive shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 * Fix: kms alias will exit when starting Kong fails.
   [#503](https://github.com/Kong/kong-pongo/pull/503).
 
+* Feat: add automatic reloads for interactive shells. This will watch plugin files as
+  well as the dbless config file and reload upon changes.
+  [#504](https://github.com/Kong/kong-pongo/pull/504).
+
 * Fix: health-checks on Pongo container. Use proper prefix.
   [#456](https://github.com/Kong/kong-pongo/pull/456).
 

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -49,7 +49,8 @@ RUN cd /kong \
     && git config --global url.https://github.com/.insteadOf git://github.com/ \
     && make dependencies $LUAROCKS_OPTS \
     && luarocks install busted-htest \
-    && luarocks install luacov
+    && luarocks install luacov \
+    && luarocks install kong-plugin-dbless-reload 0.1.0
 
 
 # make sure resty, LuaJIT, and our custom Busted are in our path

--- a/assets/pongo_profile.sh
+++ b/assets/pongo_profile.sh
@@ -15,6 +15,17 @@ if [ -d /usr/local/share/lua/5.1/ ]; then
   ln -s /usr/local/share/lua/5.1/ /rockstree
 fi
 
+# enable the dbless-reload plugin for auto reloading on plugin/config changes
+if [ "$KONG_PLUGINS" != "" ]; then
+  export KONG_PLUGINS=$KONG_PLUGINS,dbless-reload
+else
+  export KONG_PLUGINS=dbless-reload
+fi
+echo "Kong auto-reload is enabled for custom-plugins and dbless-configurations. Once you"
+echo "have started Kong, it will automatically reload to reflect any changes in the files."
+echo "Use 'pongo tail' on the host to verify, or do 'export KONG_RELOAD_CHECK_INTERVAL=0' in"
+echo "this shell to disable it."
+
 # We want this to output without expanding variables
 # shellcheck disable=SC2016
 echo 'PS1="\[\e[00m\]\[\033[1;34m\][$PS1_KONG_VERSION:\[\e[91m\]$PS1_REPO_NAME\$(/pongo/parse_git_branch.sh)\[\033[1;34m\]:\[\033[1;92m\]\w\[\033[1;34m\]]$\[\033[00m\] "' >> /root/.bashrc


### PR DESCRIPTION
In an interactive shell, when Kong is running, it will now automatically reload after changes to the plugin or the dbless config file.