### PR TITLE
fix(build): add insecure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ git clone https://github.com/Kong/kong-pongo.git
 mkdir -p ~/.local/bin
 ln -s $(realpath kong-pongo/pongo.sh) ~/.local/bin/pongo
 ```
+### Proxies
+
+When Pongo builds images, it might fail when it is behind proxies and cannot verify the certificates. See [configuration](#configuration)
+on how to disable verification.
 
 ## Update
 
@@ -161,6 +165,10 @@ Several environment variables are available for configuration:
   Enterprise features.
 * Specify a custom image; set the image name/tag in `KONG_IMAGE` and make sure
   the image is locally available
+* When the variable `PONGO_INSECURE` is set to anything else than `'false'`, it
+  will configure curl and git (during the build) to switch off ssl verification.
+  Please ensure you understand the security consequences when using this option!
+  See also `pongo build --help`.
 
 For Kong-internal use there are some additional variables:
 

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -41,15 +41,24 @@ ARG http_proxy
 ARG https_proxy
 ARG no_proxy
 ARG ftp_proxy
+ARG PONGO_INSECURE
 
 # psmisc: provides `fuser`
 # net-tools: provides `netstat`
 
 RUN apt update \
     && apt install -y zip make jq m4 curl build-essential wget git libssl-dev zlib1g-dev lsb-release psmisc net-tools
+
+# insecure connections can be useful if the certs for any intermediate proxy are unavailable
+RUN if [ -n "$PONGO_INSECURE" ] || [ "$PONGO_INSECURE" != "false" ]; then \
+        echo "Configuring curl and git to switch off ssl-verification"; \
+        echo '--insecure' >> ~/.curlrc; \
+        git config --global http.sslVerify false; \
+    fi
+
 RUN /pongo/install-python.sh
 RUN pip3 install httpie || echo -e "\n\n\nFailed installing httpie, continuing without.\n\n\n"
-RUN curl -k -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin
+RUN curl -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin
 RUN cd /kong \
     && git config --global url.https://github.com/.insteadOf git://github.com/ \
     && make dependencies $LUAROCKS_OPTS \
@@ -57,6 +66,9 @@ RUN cd /kong \
     && luarocks install luacov \
     && luarocks install kong-plugin-dbless-reload 0.1.0
 
+# restore the insecure settings from above to secure
+RUN if [ -e ~/.bashrc ]; then rm ~/.bashrc; fi; \
+    git config --global http.sslVerify true
 
 # make sure resty, LuaJIT, and our custom Busted are in our path
 ENV PATH="/kong/bin:/usr/local/openresty/bin:/usr/local/openresty/luajit/bin:${PATH}"

--- a/assets/help/build.txt
+++ b/assets/help/build.txt
@@ -20,9 +20,15 @@ The build can be customized using the following environment variables:
                      default is "[pongo]/assets/Dockerfile'. Use that file as a
                      base for any customizations.
 
-  PONGO_FORCE_BUILD  if set to anything else than 'false' it will force a
+  PONGO_FORCE_BUILD  If set to anything else than 'false' it will force a
                      rebuild. This is equivalent to the '--force' flag, but will
                      also work with 'pongo run'.
+
+  PONGO_INSECURE  If set to anything else than 'false' it will configure curl
+                  and git to turn of tls verification when downloading files
+                  during the build. This can be used with issues around
+                  certificate validation behind proxies. Make sure you
+                  understand the security consequences when using this option!
 
 If neither KONG_VERSION nor KONG_IMAGE is specified it will default to the
 latest Kong open source version.

--- a/pongo.sh
+++ b/pongo.sh
@@ -744,6 +744,7 @@ function build_image {
     --build-arg https_proxy="$https_proxy" \
     --build-arg ftp_proxy="$ftp_proxy" \
     --build-arg no_proxy="$no_proxy" \
+    --build-arg PONGO_INSECURE="$PONGO_INSECURE" \
     --build-arg KONG_BASE="$KONG_IMAGE" \
     --build-arg KONG_DEV_FILES="./kong-versions/$VERSION/kong" \
     --tag "$KONG_TEST_IMAGE" \


### PR DESCRIPTION
Adds the `PONGO_INSECURE` option to use curl and git during the build without ssl-verification.