### PR TITLE
fix(proxy): ensure proxy config availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 * Fix: kms alias will exit when starting Kong fails.
   [#503](https://github.com/Kong/kong-pongo/pull/503).
 
+* Fix: proxy config will be passed upon build and again on run.
+  [#514](https://github.com/Kong/kong-pongo/pull/514).
+
 * Feat: add automatic reloads for interactive shells. This will watch plugin files as
   well as the dbless config file and reload upon changes.
   [#504](https://github.com/Kong/kong-pongo/pull/504).

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -37,6 +37,11 @@ ENV LUAROCKS_OPENSSL_DIR=$KONG_LIBRARY_PREFIX
 
 ENV LUAROCKS_OPTS="CRYPTO_DIR=$LUAROCKS_CRYPTO_DIR OPENSSL_DIR=$LUAROCKS_OPENSSL_DIR"
 
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+ARG ftp_proxy
+
 # psmisc: provides `fuser`
 # net-tools: provides `netstat`
 

--- a/pongo.sh
+++ b/pongo.sh
@@ -139,6 +139,23 @@ function globals {
     export SQUID_IMAGE=sameersbn/squid:$SQUID
   fi
 
+  # proxy config, ensure it's set in all lower-case
+  # shellcheck disable=SC2153
+  if [[ -z $http_proxy ]] && [[ -n $HTTP_PROXY ]]; then
+    export http_proxy=$HTTP_PROXY
+  fi
+  # shellcheck disable=SC2153
+  if [[ -z $https_proxy ]] && [[ -n $HTTPS_PROXY ]]; then
+    export https_proxy=$HTTPS_PROXY
+  fi
+  # shellcheck disable=SC2153
+  if [[ -z $ftp_proxy ]] && [[ -n $FTP_PROXY ]]; then
+    export ftp_proxy=$FTP_PROXY
+  fi
+  # shellcheck disable=SC2153
+  if [[ -z $no_proxy ]] && [[ -n $NO_PROXY ]]; then
+    export no_proxy=$NO_PROXY
+  fi
 
   # Commandline related variables
   unset ACTION
@@ -723,10 +740,10 @@ function build_image {
   $WINPTY_PREFIX docker build \
     -f "$DOCKER_FILE" \
     --build-arg PONGO_VERSION="$PONGO_VERSION" \
-    --build-arg http_proxy \
-    --build-arg https_proxy \
-    --build-arg ftp_proxy \
-    --build-arg no_proxy \
+    --build-arg http_proxy="$http_proxy" \
+    --build-arg https_proxy="$https_proxy" \
+    --build-arg ftp_proxy="$ftp_proxy" \
+    --build-arg no_proxy="$no_proxy" \
     --build-arg KONG_BASE="$KONG_IMAGE" \
     --build-arg KONG_DEV_FILES="./kong-versions/$VERSION/kong" \
     --tag "$KONG_TEST_IMAGE" \
@@ -1142,6 +1159,10 @@ function main {
     compose run --rm --use-aliases \
       -e KONG_LICENSE_DATA \
       -e KONG_TEST_DONT_CLEAN \
+      -e http_proxy \
+      -e https_proxy \
+      -e no_proxy \
+      -e ftp_proxy \
       -e PONGO_CLIENT_VERSION="$PONGO_VERSION" \
       kong \
       "$WINDOWS_SLASH/bin/bash" "-c" "bin/busted --helper=$WINDOWS_SLASH/pongo/busted_helper.lua ${busted_params[*]} ${busted_files[*]}"
@@ -1204,6 +1225,10 @@ function main {
     compose run --rm --use-aliases \
       -e KONG_LICENSE_DATA \
       -e PONGO_CLIENT_VERSION="$PONGO_VERSION" \
+      -e http_proxy \
+      -e https_proxy \
+      -e no_proxy \
+      -e ftp_proxy \
       -e KONG_LOG_LEVEL \
       -e KONG_ANONYMOUS_REPORTS \
       -e SUPPRESS_KONG_VERSION="$suppress_kong_version" \
@@ -1257,6 +1282,10 @@ function main {
       --workdir="$WINDOWS_SLASH/kong-plugin" \
       -e KONG_LICENSE_DATA \
       -e PONGO_CLIENT_VERSION="$PONGO_VERSION" \
+      -e http_proxy \
+      -e https_proxy \
+      -e no_proxy \
+      -e ftp_proxy \
       -e KONG_LOG_LEVEL \
       -e KONG_ANONYMOUS_REPORTS \
       -e KONG_PG_DATABASE="kong_tests" \


### PR DESCRIPTION
proxy config is not retained during the build. It uses the host config during build and will be set again upon run/shell.

So sharing the created Pongo image will not share the proxy config.