### PR TITLE
fix(httpie): do not fail the build if httpie fails to install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 ## unreleased
 
+* Fix: do not fail the build if httpie cannot be installed. Now continues the
+  build since it is optional.
+  [#515](https://github.com/Kong/kong-pongo/pull/515).
+
 * Fix: the --debug option will now output full buildlogs again using buildkit
   [#513](https://github.com/Kong/kong-pongo/pull/513).
 

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -48,7 +48,7 @@ ARG ftp_proxy
 RUN apt update \
     && apt install -y zip make jq m4 curl build-essential wget git libssl-dev zlib1g-dev lsb-release psmisc net-tools
 RUN /pongo/install-python.sh
-RUN pip3 install httpie
+RUN pip3 install httpie || echo -e "\n\n\nFailed installing httpie, continuing without.\n\n\n"
 RUN curl -k -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin
 RUN cd /kong \
     && git config --global url.https://github.com/.insteadOf git://github.com/ \


### PR DESCRIPTION
Failures can happen if pip.conf isn't available and security settings like proxies are required. Now we will just skip the install.