### PR TITLE
fix(deps): error out if compose up fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
   older images after a Pongo upgrade. A new image will automatically be build now.
   [#516](https://github.com/Kong/kong-pongo/pull/516).
 
+* Fix: fail if the compose-up command fails. To prevent hanging while waiting for a
+  health-check to go healthy.
+  [#522](https://github.com/Kong/kong-pongo/pull/522).
+
 * Fix: do not fail the build if httpie cannot be installed. Now continues the
   build since it is optional.
   [#515](https://github.com/Kong/kong-pongo/pull/515).

--- a/pongo.sh
+++ b/pongo.sh
@@ -694,7 +694,7 @@ function ensure_available {
   fi
   if [[ ! $? -eq 0 ]]; then
     msg "auto-starting the test environment, use the 'pongo down' action to stop it"
-    compose_up
+    compose_up || err "failed to start the test environment"
   fi
 
   local dependency
@@ -845,7 +845,7 @@ function pongo_clean {
 
 function pongo_expose {
   local dependency="expose"
-  healthy "$(cid "$dependency")" "$dependency" || compose up -d "$dependency"
+  healthy "$(cid "$dependency")" "$dependency" || compose up -d "$dependency" || err "failed to start '$dependency'"
   wait_for_dependency "$dependency"
 }
 


### PR DESCRIPTION
typically happens when network ports are in use. Previously it would just hang waiting for a non-started service to go healthy.