### PR TITLE
chore(cleanup): remove dead-code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@
 * Chore: remove deprecated docker repo.
   [#475](https://github.com/Kong/kong-pongo/pull/475).
 
+* Chore: remove some deadcode and remnants of Pulp usage.
+  [#523](https://github.com/Kong/kong-pongo/pull/523).
+
 ---
 
 ## 2.9.0 released 08-Nov-2023

--- a/README.md
+++ b/README.md
@@ -172,9 +172,6 @@ Several environment variables are available for configuration:
 
 For Kong-internal use there are some additional variables:
 
-* `PULP_USERNAME` and `PULP_PASSWORD` to automatically download the Kong
-  Enterprise CI license. See [Setting up CI](#setting-up-ci) for some Pulp
-  environment variable examples.
 * `GITHUB_TOKEN` the Github token to get access to the Kong Enterprise source
   code. This is only required for development builds, not for released
   versions of Kong.


### PR DESCRIPTION
1. non-public enterprise repo
2. license fetching using deprecated Pulp instance