### PR TITLE
[DO NOT MERGE] this is part of the `support/3.4` branch now

### DIFF
--- a/assets/docker-compose-linux-extend.yml
+++ b/assets/docker-compose-linux-extend.yml
@@ -1,0 +1,6 @@
+version: '3.5'
+
+services:
+  kong:
+    volumes:
+      - ${PONGO_WD}/servroot:/kong-prefix

--- a/assets/docker-compose-nonlinux-extend.yml
+++ b/assets/docker-compose-nonlinux-extend.yml
@@ -1,0 +1,6 @@
+version: '3.5'
+
+services:
+  kong:
+    volumes:
+      - ${PONGO_WD}/servroot/logs:/kong-prefix/logs

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -62,8 +62,7 @@ if [ -z "$KONG_DNS_RESOLVER" ]; then
   fi
 fi
 
-# set working dir in mounted volume to be able to check the logs
-export KONG_PREFIX=/kong-plugin/servroot
+export KONG_PREFIX=/kong-prefix
 
 # set debug logs; specifically for the 'shell' command, tests already have it
 export KONG_LOG_LEVEL=debug
@@ -106,14 +105,14 @@ fi
 
 # Modify the 'kong' user to match the ownership of the mounted plugin folder
 # Kong will not start because of permission errors if it cannot write to the
-# /kong-plugin/servroot folder (which resides on the mount).
+# /kong-prefix folder (which created by volume mount /kong-prefix/logs by root).
 # Since those permissions are controlled by the host, we update the 'kong' user
 # inside the container to match the UID and GID.
-if [ -d /kong-plugin ]; then
+if [ -d /kong-prefix ]; then
   KONG_UID=$(id -u kong)
   KONG_GID=$(id -g kong)
-  MOUNT_UID=$(stat -c "%u" /kong-plugin)
-  MOUNT_GID=$(stat -c "%g" /kong-plugin)
+  MOUNT_UID=$(stat -c "%u" /kong-prefix)
+  MOUNT_GID=$(stat -c "%g" /kong-prefix)
   if [ ! "$KONG_GID" = "$MOUNT_GID" ]; then
     # change KONG_GID to the ID of the folder owner group
     groupmod -g "$MOUNT_GID" --non-unique kong

--- a/pongo.sh
+++ b/pongo.sh
@@ -28,6 +28,14 @@ function globals {
   IMAGE_BASE_PREFIX="kong-pongo-"
   IMAGE_BASE_NAME=$IMAGE_BASE_PREFIX$PONGO_VERSION
 
+  # macOS or WSL working on a drvfs mount doesn't support named pipes or Unix Domain Socket
+  if [ "$(uname -s)" == "Darwin" ] || ! (rm -f .pongo_test.sock; mkfifo .pongo_test.sock) 2>/dev/null; then
+    rm -f .pongo_test.sock
+    DOCKER_COMPOSE_FILES="$DOCKER_COMPOSE_FILES -f ${LOCAL_PATH}/assets/docker-compose-nonlinux-extend.yml"
+  else
+    DOCKER_COMPOSE_FILES="$DOCKER_COMPOSE_FILES -f ${LOCAL_PATH}/assets/docker-compose-linux-extend.yml"
+  fi
+
   # the path where the plugin source is located, as seen from Pongo (this script)
   KONG_TEST_PLUGIN_PATH=$(realpath .)
 

--- a/pongo.sh
+++ b/pongo.sh
@@ -28,14 +28,6 @@ function globals {
   IMAGE_BASE_PREFIX="kong-pongo-"
   IMAGE_BASE_NAME=$IMAGE_BASE_PREFIX$PONGO_VERSION
 
-  # macOS or WSL working on a drvfs mount doesn't support named pipes or Unix Domain Socket
-  if [ "$(uname -s)" == "Darwin" ] || ! (rm -f .pongo_test.sock; mkfifo .pongo_test.sock) 2>/dev/null; then
-    rm -f .pongo_test.sock
-    DOCKER_COMPOSE_FILES="$DOCKER_COMPOSE_FILES -f ${LOCAL_PATH}/assets/docker-compose-nonlinux-extend.yml"
-  else
-    DOCKER_COMPOSE_FILES="$DOCKER_COMPOSE_FILES -f ${LOCAL_PATH}/assets/docker-compose-linux-extend.yml"
-  fi
-
   # the path where the plugin source is located, as seen from Pongo (this script)
   KONG_TEST_PLUGIN_PATH=$(realpath .)
 
@@ -104,6 +96,13 @@ function globals {
     export PONGO_PLATFORM="WINDOWS"
   else
     export PONGO_PLATFORM="LINUX"
+  fi
+
+  # macOS or WSL working on a drvfs mount doesn't support named pipes or Unix Domain Socket
+  if [ "$PONGO_PLATFORM" == "LINUX" ]; then
+    DOCKER_COMPOSE_FILES="$DOCKER_COMPOSE_FILES -f ${LOCAL_PATH}/assets/docker-compose-linux-extend.yml"
+  else
+    DOCKER_COMPOSE_FILES="$DOCKER_COMPOSE_FILES -f ${LOCAL_PATH}/assets/docker-compose-nonlinux-extend.yml"
   fi
 
   # when running CI do we have the required secrets available? (used for EE only)


### PR DESCRIPTION
This branch existed to use the "insecure build" feature (#509) combined with 3.4 support for the broken Unix sockets.

Since the insecure feature has been merged, this is now identical to the `support/3.4` branch and hence this `supinsec` branch will no longer be updated. This PR is just here to inform users that this branch will be deleted by end of 2024.
