### PR TITLE
fix(redis): disabling protected mode and explicit redis-server command

### DIFF
--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -91,13 +91,14 @@ services:
     volumes:
       - "./redis/server.crt:/usr/local/etc/redis/server.crt"
       - "./redis/server.key:/usr/local/etc/redis/server.key"
-    command: >-
-      --tls-port 6380
-      --tls-cert-file /usr/local/etc/redis/server.crt
-      --tls-key-file /usr/local/etc/redis/server.key
-      --tls-cluster no
-      --tls-replication no
-      --tls-auth-clients no
+    environment:
+      - REDIS_TLS_PORT=6380
+      - REDIS_TLS_CERT_FILE=/usr/local/etc/redis/server.crt
+      - REDIS_TLS_KEY_FILE=/usr/local/etc/redis/server.key
+      - REDIS_TLS_CLUSTER=no
+      - REDIS_TLS_REPLICATION=no
+      - REDIS_TLS_AUTH_CLIENTS=no
+      - REDIS_PROTECTED_MODE=no
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s


### PR DESCRIPTION
This PR fixes incompatibilities when running `redis/redis-stack` with the additional modules (that includes additional modules, like AI vectors), and still is backwards compatible with the previous defaults.