### PR TITLE
fix(docker-compose): remove deprecated version key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 * Fix: properly resolve Kong-versions in case of double digits, eg. 3.4.3.12
   [#619](https://github.com/Kong/kong-pongo/pull/619).
 
+* Fix: remove version key from docker compose to prevent deprecation warning
+  [#622](https://github.com/Kong/kong-pongo/pull/622).
+
 
 ---
 

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 networks:
   pongo-test-network:
     name: ${SERVICE_NETWORK_NAME}


### PR DESCRIPTION
In Docker Compose, `version` is deprecated and returns the following deprecation message:

```
WARN[0000] /kong-pongo/assets/docker-compose.yml: `version` is obsolete
```

This PR removes `version`.