### PR TITLE
Revert 2 changes that broke the Kong-Enterprise tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,6 @@
 
 ## Unreleased
 
-* Feat: enable FIPS mode by passing `KONG_TEST_FIPS` env variable
-  [#615](https://github.com/Kong/kong-pongo/pull/615).
-
 * Fix: properly resolve Kong-versions in case of double digits, eg. 3.4.3.12
   [#619](https://github.com/Kong/kong-pongo/pull/619).
 

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -89,14 +89,13 @@ services:
     volumes:
       - "./redis/server.crt:/usr/local/etc/redis/server.crt"
       - "./redis/server.key:/usr/local/etc/redis/server.key"
-    environment:
-      - REDIS_TLS_PORT=6380
-      - REDIS_TLS_CERT_FILE=/usr/local/etc/redis/server.crt
-      - REDIS_TLS_KEY_FILE=/usr/local/etc/redis/server.key
-      - REDIS_TLS_CLUSTER=no
-      - REDIS_TLS_REPLICATION=no
-      - REDIS_TLS_AUTH_CLIENTS=no
-      - REDIS_PROTECTED_MODE=no
+    command: >-
+      --tls-port 6380
+      --tls-cert-file /usr/local/etc/redis/server.crt
+      --tls-key-file /usr/local/etc/redis/server.key
+      --tls-cluster no
+      --tls-replication no
+      --tls-auth-clients no
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/pongo.sh
+++ b/pongo.sh
@@ -1181,8 +1181,6 @@ function main {
     compose run --rm --use-aliases \
       -e KONG_LICENSE_DATA \
       -e KONG_TEST_DONT_CLEAN \
-      -e KONG_TEST_FIPS \
-      -e KONG_TEST_LICENSE_PATH \
       -e http_proxy \
       -e https_proxy \
       -e no_proxy \


### PR DESCRIPTION
This reverts:

- PR #615 by @Water-Melon 
- PR #616 by @subnetmarco 

Reverting is required because of releasing Kong 3.8 support in Pongo