### PR TITLE
feat(docker-compose): add FIPS environment variable to docker-compose for busted tests

### DIFF
--- a/pongo.sh
+++ b/pongo.sh
@@ -1181,6 +1181,8 @@ function main {
     compose run --rm --use-aliases \
       -e KONG_LICENSE_DATA \
       -e KONG_TEST_DONT_CLEAN \
+      -e KONG_TEST_FIPS \
+      -e KONG_TEST_LICENSE_PATH \
       -e http_proxy \
       -e https_proxy \
       -e no_proxy \

--- a/pongo.sh
+++ b/pongo.sh
@@ -1182,7 +1182,6 @@ function main {
       -e KONG_LICENSE_DATA \
       -e KONG_TEST_DONT_CLEAN \
       -e KONG_TEST_FIPS \
-      -e KONG_TEST_LICENSE_PATH \
       -e http_proxy \
       -e https_proxy \
       -e no_proxy \


### PR DESCRIPTION
[KAG-5187](https://konghq.atlassian.net/browse/KAG-5187)

The sibling EE PR: https://github.com/Kong/kong-ee/pull/10031

[KAG-5187]: https://konghq.atlassian.net/browse/KAG-5187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ