### PR TITLE
feat: add custom ca certificate support for pongo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,19 @@ Some helpfull examples:
 
 [Back to ToC](#table-of-contents)
 
+## Custom CA
+
+If you are running pongo e.g. behind a corporate traffic-inspector, and that normally requires you to add 
+a custom CA certificate into the operating system or container truststore, use the following flag:
+
+`PONGO_CUSTOM_CA_CERT=/path/to/custom/ca.crt`
+
+For example:
+
+```sh
+$ PONGO_CUSTOM_CA_CERT="$(pwd)/zscaler-root.crt" pongo up
+```
+
 ## Debugging
 
 This section is about debugging plugin code. If you have trouble with the Pongo

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Environment variables:
   KONG_LICENSE_DATA
                 set this variable with the Kong Enterprise license data
 
+  PONGO_CUSTOM_CA_CERT
+                set this to the absolute path of a custom CA to add to the
+                container's truststore
+
   POSTGRES      the version of the Postgres dependency to use (default 9.5)
   CASSANDRA     the version of the Cassandra dependency to use (default 3.11)
   REDIS         the version of the Redis dependency to use (default 6.2.6)

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -24,6 +24,17 @@ COPY assets/pongo_profile.sh         /etc/profile.d/pongo_profile.sh
 COPY assets/install-python.sh        /pongo/install-python.sh
 
 USER root
+
+# add custom CA cert in case of corporate proxy - this is a hack that ignores if the file is missing
+COPY custom_ca.crt /usr/local/share/ca-certificates/custom_ca.crt
+RUN <<EOF
+    if [ -s /usr/local/share/ca-certificates/custom_ca.crt ]; then
+        update-ca-certificates;
+    else
+        rm -f /usr/local/share/ca-certificates/custom_ca.crt;
+    fi
+EOF
+
 # httpie and jq are genric utilities usable from the shell action.
 # LuaRocks needs (un)zip to (un)pack rocks, and dev essentials to build.
 # Setup the development dependencies using the make target
@@ -55,6 +66,7 @@ RUN if [ -n "$PONGO_INSECURE" ] || [ "$PONGO_INSECURE" != "false" ]; then \
         echo '--insecure' >> ~/.curlrc; \
         git config --global http.sslVerify false; \
     fi
+
 
 RUN /pongo/install-python.sh
 RUN pip3 install httpie || echo -e "\n\n\nFailed installing httpie, continuing without.\n\n\n"

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -67,7 +67,6 @@ RUN if [ -n "$PONGO_INSECURE" ] || [ "$PONGO_INSECURE" != "false" ]; then \
         git config --global http.sslVerify false; \
     fi
 
-
 RUN /pongo/install-python.sh
 RUN pip3 install httpie || echo -e "\n\n\nFailed installing httpie, continuing without.\n\n\n"
 RUN curl -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin

--- a/assets/help/pongo.txt
+++ b/assets/help/pongo.txt
@@ -56,6 +56,10 @@ Environment variables:
   KONG_LICENSE_DATA
                 set this variable with the Kong Enterprise license data
 
+  PONGO_CUSTOM_CA_CERT
+                set this to the absolute path of a custom CA to add to the
+                container's truststore
+
   POSTGRES_IMAGE   the Postgres image to use (default postgres:9.5)
   CASSANDRA_IMAGE  the Cassandra image to use (default cassandra:3.11)
   REDIS_IMAGE      the Redis dependency to use (default redis:6.2.6-alpine)

--- a/pongo.sh
+++ b/pongo.sh
@@ -758,6 +758,14 @@ function build_image {
   fi
 
   msg "starting build of image '$KONG_TEST_IMAGE'"
+  
+  if [ -n "$PONGO_CUSTOM_CA_CERT" ]; then
+    msg "custom CA is set: $PONGO_CUSTOM_CA_CERT"
+    cp "$PONGO_CUSTOM_CA_CERT" "$LOCAL_PATH/custom_ca.crt"
+  else
+    echo -n '' > "$LOCAL_PATH/custom_ca.crt"
+  fi
+
   $WINPTY_PREFIX docker build \
     -f "$DOCKER_FILE" \
     --build-arg PONGO_VERSION="$PONGO_VERSION" \
@@ -769,7 +777,7 @@ function build_image {
     --build-arg KONG_BASE="$KONG_IMAGE" \
     --build-arg KONG_DEV_FILES="./kong-versions/$VERSION/kong" \
     --tag "$KONG_TEST_IMAGE" \
-    "$LOCAL_PATH" || err "Error: failed to build test environment"
+    "$LOCAL_PATH" || err "Error: failed to build test environment";
 
   msg "image '$KONG_TEST_IMAGE' successfully build"
 }


### PR DESCRIPTION
This allows pongo to add a custom CA into the container image's OS truststore during the build/up.

It allows the user to add e.g. their employer's traffic inspection CA.

It makes these all works, when running behind e.g. Zscaler:

* Kong outbound requests
* pip3
* luarocks
* git
* probably everything else
