### PR TITLE
fix(luarocks): fix the luarocks 65536 limitation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.GHA_DOCKERHUB_PULL_USER }}
         DOCKER_PASSWORD: ${{ secrets.GHA_KONG_ORG_DOCKERHUB_PUBLIC_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GHA_KONG_BOT_READ_TOKEN }}
+        KONG_VERSION: "3.10.0.2" # will use LTS 3.11.0.0 or dev-ee
 
       run: |
        assets/ci/run.sh --suite "Pongo test suite" $TEST_SCRIPT

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -56,15 +56,54 @@ RUN if [ -n "$PONGO_INSECURE" ] || [ "$PONGO_INSECURE" != "false" ]; then \
         git config --global http.sslVerify false; \
     fi
 
+RUN <<-EOF
+  apt-get install -y unzip
+  curl -Lo /tmp/luarocks-3.12.1-linux-x86_64.zip https://luarocks.github.io/luarocks/releases/luarocks-3.12.1-linux-x86_64.zip
+  unzip -j /tmp/luarocks-3.12.1-linux-x86_64.zip luarocks-3.12.1-linux-x86_64/luarocks luarocks-3.12.1-linux-x86_64/luarocks-admin -d /usr/local/sbin/
+  hash -r
+  luarocks --version
+
+  mkdir -p /usr/local/etc/luarocks
+  echo -n '
+lua_interpreter = "luajit"
+rocks_trees = {
+   {
+      name = "user",
+      root = "/root/.luarocks"
+   },
+   {
+      name = "system",
+      root = "/usr/local"
+   }
+}
+variables = {
+   LUA_INCDIR = "/usr/local/openresty/luajit/include/luajit-2.1",
+   LUA = "/usr/local/openresty/luajit/bin/luajit",
+   LUALIB = "libluajit-5.1.so",
+   LUA_BINDIR = "/usr/local/openresty/luajit/bin",
+   LUA_DIR = "/usr/local/openresty/luajit",
+   LUA_INCDIR = "/usr/local/openresty/luajit/include/luajit-2.1",
+   LUA_INCDIR_OK = true,
+   LUA_LIBDIR = "/usr/local/openresty/luajit/lib",
+   LUA_LIBDIR_FILE = "libluajit-5.1.so",
+}
+' >| /usr/local/etc/luarocks/config-5.1.lua
+
+  sed -i 's#luarocks list#luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit list#g' /kong/Makefile
+  sed -i 's#luarocks install#luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit install#g' /kong/Makefile
+
+  rm -f /tmp/luarocks-3.12.1-linux-x86_64.zip
+EOF
+
 RUN /pongo/install-python.sh
 RUN pip3 install httpie || echo -e "\n\n\nFailed installing httpie, continuing without.\n\n\n"
 RUN curl -s -S -L https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz | tar xz -C /kong/bin
 RUN cd /kong \
     && git config --global url.https://github.com/.insteadOf git://github.com/ \
     && make dependencies $LUAROCKS_OPTS \
-    && luarocks install busted-htest \
-    && luarocks install luacov \
-    && luarocks install kong-plugin-dbless-reload 0.1.0
+    && luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit install busted-htest \
+    && luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit install luacov \
+    && luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit install kong-plugin-dbless-reload 0.1.0
 
 # restore the insecure settings from above to secure
 RUN if [ -e ~/.bashrc ]; then rm ~/.bashrc; fi; \

--- a/assets/ci/pongo_build.test.sh
+++ b/assets/ci/pongo_build.test.sh
@@ -9,7 +9,7 @@ function run_test {
 
   # this version should be the latest patch release of a series,
   # eg. 2.0.x == 2.0.5
-  TEST_VERSION=2.0.5
+  TEST_VERSION=3.10.0.2  # will use LTS 3.11.0.0 or dev-ee
 
 
   ttest "builds the specified image: $TEST_VERSION"

--- a/assets/ci/pongo_run_ce.test.sh
+++ b/assets/ci/pongo_run_ce.test.sh
@@ -7,7 +7,7 @@ function run_test {
   source pongo_run.helper.sh
 
   # testing Kong CE, with the 99 latest releases (not taking patch releases into account)
-  run_version_test "Kong" 99
+  run_version_test "Kong" 2
   popd
 }
 

--- a/assets/ci/pongo_run_ee.test.sh
+++ b/assets/ci/pongo_run_ee.test.sh
@@ -7,7 +7,7 @@ function run_test {
   source pongo_run.helper.sh
 
   # testing Kong Enterprise, with the 99 latest releases (not taking patch releases into account)
-  run_version_test "Kong Enterprise" 99
+  run_version_test "Kong Enterprise" 2
   popd
 }
 

--- a/assets/default-pongo-setup.sh
+++ b/assets/default-pongo-setup.sh
@@ -10,10 +10,10 @@ cd /kong-plugin || { echo "Failure to enter /kong-plugin"; exit 1; }
 for rockspec in $(find /kong-plugin -maxdepth 1 -type f -name '*.rockspec'); do
   rockname=$(echo "$rockspec" | sed "s/\/kong-plugin\///" | sed "s/-[0-9a-zA-Z.]*-[0-9].rockspec//")
   # remove the rock if another version is already installed
-  if luarocks list | grep "^$rockname$" ; then
-    luarocks remove --force "$rockname"
+  if luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit list | grep "^$rockname$" ; then
+    luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit remove --force "$rockname"
   fi
   # install any required dependencies
-  luarocks install --only-deps "$rockspec"
+  luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit install --only-deps "$rockspec"
 done
 

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -21,7 +21,7 @@ fi
 if [ -z "$KONG_ADMIN_LISTEN" ]; then
   # admin_api is by default not exposed, other than 127.0.0.1, since different
   # Kong versions have different settings, find the default and replace it.
-  FILE_WITH_KONG_DEFAULTS=$(luarocks show kong | grep -oEi '/.*/kong_defaults.lua')
+  FILE_WITH_KONG_DEFAULTS=$(luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit show kong | grep -oEi '/.*/kong_defaults.lua')
   DEFAULT_ADMIN_LISTEN_SETTING=$(grep admin_listen < "$FILE_WITH_KONG_DEFAULTS" | sed 's/admin_listen *= *//')
 
   # export to override defaults in file, with 0.0.0.0 instead of 127.0.0.1

--- a/assets/pongo_pack.lua
+++ b/assets/pongo_pack.lua
@@ -7,5 +7,5 @@ local dir = require("pl.dir")
 local rockspecs = dir.getfiles("/kong-plugin/", "*.rockspec")
 for _, filename in ipairs(rockspecs) do
   local rockname = filename:match("([^/]+)%-[%d%.%a]+%-%d+%.rockspec")
-  os.execute(("cd /kong-plugin && luarocks make %s && luarocks pack %s"):format(filename, rockname))
+  os.execute(("cd /kong-plugin && luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit make %s && luarocks --lua-version 5.1 --lua-dir /usr/local/openresty/luajit pack %s"):format(filename, rockname))
 end


### PR DESCRIPTION
The Pongo is special in that it has to support packages/images that were released before the bug.

So if we use Pongo to test against those releases. The built-in luarocks would error.

What is worse, any new PR to the Pongo repo would fail the CI tests.

We have the following potential options:

1. Point the `--server` option to `kongrocks-dev`.
2. Manually replace the built-in luarocks with the latest bump.
3. `LUAROCKS_OPTS`.

FTI-6780