### PR TITLE
fix: the `sockets` of Kong couldn't mount to the correct directory in windows.

### DIFF
--- a/assets/ci/pongo_docker.test.sh
+++ b/assets/ci/pongo_docker.test.sh
@@ -94,7 +94,7 @@ function run_test {
   tmessage "cleanup; clear working directory (servroot)"
   if [ -d ./servroot ]; then
     #rm -rf servroot                   doesn't work; priviledge issue
-    ../../docker/pongo-docker.sh shell rm -rf /kong-plugin/servroot
+    ../../docker/pongo-docker.sh shell sh -c 'find /kong-plugin/servroot -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true; find "$PONGO_PREFIX_HOST_MIRROR" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true'
   fi
 
 

--- a/assets/ci/pongo_run.helper.sh
+++ b/assets/ci/pongo_run.helper.sh
@@ -118,7 +118,7 @@ function test_single_version {
   # cleanup working directory
   if [ -d ./servroot ]; then
     #rm -rf servroot                   doesn't work; priviledge issue
-    KONG_VERSION=$VERSION pongo shell rm -rf /kong-plugin/servroot
+    KONG_VERSION=$VERSION pongo shell sh -c 'find /kong-plugin/servroot -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true; find "$PONGO_PREFIX_HOST_MIRROR" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true'
   fi
 
   ttest "pongo down"

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -2,6 +2,9 @@ networks:
   pongo-test-network:
     name: ${SERVICE_NETWORK_NAME}
 
+volumes:
+  pongo-kong-runtime-prefix:
+
 services:
   expose:
     image: pongo-expose
@@ -151,6 +154,7 @@ services:
     environment:
       - KONG_CASSANDRA_CONTACT_POINTS=${SERVICE_NETWORK_NAME}-cassandra.${SERVICE_NETWORK_NAME}
       - KONG_PG_HOST=${SERVICE_NETWORK_NAME}-postgres.${SERVICE_NETWORK_NAME}
+      - PONGO_PREFIX_HOST_MIRROR=/kong-prefix-host-mirror
       - PONGO_COMMAND=${ACTION}
       - PONGO_NETWORK=${SERVICE_NETWORK_NAME}
       - PONGO_ID=${PROJECT_ID}
@@ -172,3 +176,5 @@ services:
           - ${SERVICE_NETWORK_NAME}-kong.${SERVICE_NETWORK_NAME}
     volumes:
       - ${PONGO_WD}:/kong-plugin
+      - pongo-kong-runtime-prefix:/kong-plugin/servroot
+      - ${PONGO_WD}/servroot:/kong-prefix-host-mirror

--- a/assets/pongo_entrypoint.sh
+++ b/assets/pongo_entrypoint.sh
@@ -64,6 +64,7 @@ fi
 
 # set working dir in mounted volume to be able to check the logs
 export KONG_PREFIX=/kong-plugin/servroot
+export PONGO_PREFIX_HOST_MIRROR=${PONGO_PREFIX_HOST_MIRROR:-/kong-prefix-host-mirror}
 
 # set debug logs; specifically for the 'shell' command, tests already have it
 export KONG_LOG_LEVEL=debug
@@ -128,6 +129,47 @@ if [ -d /kong-plugin ]; then
   unset MOUNT_UID
   unset MOUNT_GID
 fi
+
+sync_prefix_debug_artifacts() {
+  if [ ! -d "$PONGO_PREFIX_HOST_MIRROR" ] || [ ! -d "$KONG_PREFIX" ]; then
+    return
+  fi
+
+  mkdir -p "$PONGO_PREFIX_HOST_MIRROR" "$PONGO_PREFIX_HOST_MIRROR/logs"
+
+  find "$KONG_PREFIX" -maxdepth 1 -type f -exec cp -fp {} "$PONGO_PREFIX_HOST_MIRROR"/ \;
+
+  if [ -d "$KONG_PREFIX/logs" ]; then
+    find "$KONG_PREFIX/logs" -maxdepth 1 -type f -exec cp -fp {} "$PONGO_PREFIX_HOST_MIRROR/logs"/ \;
+  fi
+}
+
+start_prefix_debug_sync() {
+  if [ ! -d "$PONGO_PREFIX_HOST_MIRROR" ]; then
+    return
+  fi
+
+  mkdir -p "$PONGO_PREFIX_HOST_MIRROR"
+  find "$PONGO_PREFIX_HOST_MIRROR" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
+  mkdir -p "$PONGO_PREFIX_HOST_MIRROR/logs"
+
+  sync_prefix_debug_artifacts
+
+  while true; do
+    sync_prefix_debug_artifacts
+    sleep 1
+  done &
+}
+
+# Docker Desktop bind mounts on Windows and other non-Linux hosts cannot host
+# Unix sockets reliably. Run the full Kong prefix from container-local storage
+# and mirror logs/configs back to the host workspace for inspection.
+if [ -d /kong-plugin ]; then
+  mkdir -p "$KONG_PREFIX" "$KONG_PREFIX/logs" "$KONG_PREFIX/pids" "$KONG_PREFIX/sockets"
+  chown kong:kong "$KONG_PREFIX" "$KONG_PREFIX/logs" "$KONG_PREFIX/pids" "$KONG_PREFIX/sockets"
+fi
+
+start_prefix_debug_sync
 
 
 if [ ! "$SUPPRESS_KONG_VERSION" = "true" ]; then


### PR DESCRIPTION
Pongo used /kong-plugin/servroot as Kong’s runtime prefix, but /kong-plugin was bind-mounted from the host workspace. On Windows Docker Desktop, Unix sockets under a bind-mounted path are unreliable, so nginx failed when Kong tried to bind runtime sockets under servroot, for example:

```bind() to unix:/kong-plugin/servroot/sockets/kd failed (5: Input/output error)```

The fix moves the full runtime servroot to a Docker-managed volume and keeps a separate host-visible mirror for logs and generated config files. This avoids the socket bind failure while preserving the existing debugging workflow.

FTI-7288