### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/kong-versions/3.11.0.0/kong/spec-ee/fixtures/kafka4/docker-compose4.yaml
+++ b/kong-versions/3.11.0.0/kong/spec-ee/fixtures/kafka4/docker-compose4.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: "bitnami/kafka:4.0.0"
+    image: "soldevelo/kafka:4.0.0"
     network_mode: "host"
     environment:
       KAFKA_CFG_NODE_ID: 0

--- a/kong-versions/3.11.0.1/kong/spec-ee/fixtures/kafka4/docker-compose4.yaml
+++ b/kong-versions/3.11.0.1/kong/spec-ee/fixtures/kafka4/docker-compose4.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: "bitnami/kafka:4.0.0"
+    image: "soldevelo/kafka:4.0.0"
     network_mode: "host"
     environment:
       KAFKA_CFG_NODE_ID: 0

--- a/kong-versions/3.11.0.2/kong/spec-ee/fixtures/kafka4/docker-compose4.yaml
+++ b/kong-versions/3.11.0.2/kong/spec-ee/fixtures/kafka4/docker-compose4.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: "bitnami/kafka:4.0.0"
+    image: "soldevelo/kafka:4.0.0"
     network_mode: "host"
     environment:
       KAFKA_CFG_NODE_ID: 0

--- a/kong-versions/3.11.0.3/kong/spec-ee/fixtures/kafka4/docker-compose4.yaml
+++ b/kong-versions/3.11.0.3/kong/spec-ee/fixtures/kafka4/docker-compose4.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: "bitnami/kafka:4.0.0"
+    image: "soldevelo/kafka:4.0.0"
     network_mode: "host"
     environment:
       KAFKA_CFG_NODE_ID: 0


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kafka:4.0.0` → [`soldevelo/kafka:4.0.0`](https://hub.docker.com/r/soldevelo/kafka)