### PR TITLE
fix(ci): pin Kong/kong-license to a commit SHA instead of @master

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v3
 
-    - uses: Kong/kong-license@master
+    - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master
       with:
         password: ${{ secrets.PULP_PASSWORD }}
         op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}


### PR DESCRIPTION
## Summary
- `Kong/kong-license`'s `master` branch has no branch protection, so the unpinned `Kong/kong-license@master` reference in `docker.yml` lets anyone with push access to that repo run code in this repo's CI, which has access to secrets.
- Pins the action to the current `master` tip (`ddccb487a0b319cef85f348b16a1ad2b6d9c1df7`), the same SHA already used by other Kong repos (e.g. kong-ee).
